### PR TITLE
Fix typo in JSON dir example

### DIFF
--- a/index.html
+++ b/index.html
@@ -432,7 +432,7 @@ dir</code></dfn> member</dt>
 <p>Here is the same example without using the default:</p>
 <pre>
 {
-    "id": {"978-0-1234-5678-X", &quot;dir&quot;=&quot;ltr&quot;},
+    "id": {"value": "978-0-1234-5678-X", "dir": "ltr"},
     "title": {"value": "Moby Dick", "lang": "en"},
     "authors": [ {"value": "Herman Melville", "lang": "en"} ],
     "language": "en-US",


### PR DESCRIPTION
Just a wee tweak to make the JSON correct.