### PR TITLE
Proposal to rewrite best practises section

### DIFF
--- a/index.html
+++ b/index.html
@@ -300,59 +300,74 @@ data in an interchange format is not a good idea. These include:</p>
 <section>
 <h2 id="bp-and-reco">Best Practices, Recommendations, and Gaps</h2>
 
-<p class=issue>This section is being actively developed. Comments on it are incredibly welcome but take the stuff in here with a grain of salt.</p>
+<div  class="ednote">
+<p>This section is being actively developed. Comments on it are incredibly welcome but take the stuff in here with a grain of salt.</p>
+
+<p>The TAG and I18N WG are <a href="https://github.com/w3ctag/design-reviews/issues/178">currently discussing</a> what the best practice recommendations should be. This section represents our understanding currently.</p>
+</div>
 
 <p>This section consists of the Internationalization (I18N) Working Group's set of best practices for identifying language and base direction in data formats on the Web. In some cases, there are gaps in existing standards, where the recommendations of the I18N WG require additional standardization or there might be barriers to full adoption.</p>
 
-<aside class=note>
-	<p>The TAG and I18N WG are <a href="https://github.com/w3ctag/design-reviews/issues/178">currently discussing</a> what the best practice recommendations should be. This section represents our understanding currently.</p>
-	<p>In this section [[RFC2119]] keywords have their usual meaning. We differentiate <em>best practices</em>, which should be adopted by all specifications and <em>recommendations</em>, which require additional standardization or which are speculative prior to adoption.</p>
-    <p class=reqex>Best practices appear with a different background color and decoration like this.</p>
-    <p class=gap>Gaps or recommendations for future work appear with a different background color and decoration list this.</p>
+<aside class="note">
+<p>In this section [[RFC2119]] keywords have their usual meaning. We differentiate <em>best practices</em>, which should be adopted by all specifications and <em>recommendations</em>, which require additional standardization or which are speculative prior to adoption.</p>
+    <p class="advisement">Best practices appear with a different background color and decoration like this.</p>
+    <p>Gaps or recommendations for future work are listed as issues.</p>
 </aside>
 
 <p>The main issue is how to establish a common <a>serialization agreement</a> between producers and consumers of data values so that each knows how to encode, find, and interpret the language and base direction of each data field. The use of metadata for supplying both the language and base direction of natural language string fields ensures that the necessary information is present, can be supplied and extracted with the minimal amount of processing, and does not require producers or consumers to scan or alter the data. </p>
-  
-<p class=req id=bp-lang-1>Use metadata to indicate the language of each natural language string field.</p>
 
-<p>There is widespread low-level support for natural language string metadata as the use of metadata for storage and interchange of the language of data values is long-established and widely supported in the basic infrastructure of the Web. This includes language attributes in [[XML]] and [[HTML]]; string types in schema languages (e.g. [[xmlschema11-2]]) or the various RDF specifications including [[JSON-LD]]; or protocol- or document format-specific provisions for language.</p>
-
-<p class=req id=bp-dir-1>Use metadata to indicate the base direction of each natural language string field.</p>
-
-<p class=gap>Schema languages, such as the RDF suite of specifications, need an in-built mechanism for associating base direction metadata with natural language string values.</p>
-
-<p>The use of <a href="#metadata">metadata</a> for indicating base direction is preferred, as it avoids requiring the consumer to interpolate the direction using methods such as <a href="#firststrong">first strong</a> or which require modification of the data itself (such as the <a href="rlm">insertion of RLM/LRM markers</a> or <a href="#paired">bidirectional controls</a>).</p>
-
-<p class=req id=bp-lang-2>For [[WebIDL]]-defined data structures, define each natural language text field as a <q><a>Localizable</a></q>.</p>
-
-<p> This combines both language and direction metadata and, if consistently adopted, makes interchange between different formats easier. Consistency between different specifications and document formats allows for the easy interchange of string data. By naming field attributes in the same way and adopting the same semantics, different specifications can more easily extract values from or add values into resources from other data sources.</p>
 
 <p>Many resources use only a single language and have a consistent base text direction. For efficiency, the following are best practices:</p>
 
-<p class=req id=bp-lang-3>Specifications and document formats MAY define a field to provide the default language for a given document.
+<p class="advisement" id="bp-default_setting">Define a field to provide the default language and base direction for all strings in a given resource.</p>
+<p class="advisement" id="bp-not_only_default">Specifications MUST NOT assume that a document-level default is sufficient.</p>
 
-<p class=req id=bp-dir-2>Specifications and document formats MAY define a field to provide the default direction for a given document.</p>
+<p>Document level defaults, when combined with per-field metadata, can reduce the overall complexity of a given document instance, since the language and direction values don't have to be repeated across many fields. However, they do not solve all language or directionality problems, and so it must be possible to override the default on a string-by-string basis.</p>
 
-<p>Document level defaults, when combined with per-field metadata, can reduce the overall complexity of a given document instance, since the language and direction values don't have to be repeated across many fields. However, they do not solve all language or directionality problems.</p>
 
-<p class=req id=bp-dir-3>Specifications MUST NOT assume that a document-level default is sufficient.</p>
 
-<p class=req id=bp-lang-4>Use of [[JSON-LD]] <code>@context</code> and the built-in <code>@language</code> attribute is RECOMMENDED as a document level default.</p>
 
-<p class=gap>There is no built-in attribute for base direction in [[JSON-LD]]. There needs to be a corresponding built-in attribute (e.g. an <q><code>@dir</code></q>) or de facto convention for indicating document-level base direction.</p>
+<p class="advisement" id="bp-use_metadata">Use metadata to indicate the language and the base direction for each natural language string.</p>
+
+<p>There is widespread low-level support for natural language string metadata because the use of metadata for storage and interchange of the language of data values is long-established and widely supported in the basic infrastructure of the Web. This includes language attributes in [[XML]] and [[HTML]]; string types in schema languages (e.g. [[xmlschema11-2]]) or the various RDF specifications including [[JSON-LD]]; or protocol- or document format-specific provisions for language.</p>
+<p>The use of <a href="#metadata">metadata</a> for indicating base direction is preferred, because it avoids requiring the consumer to interpolate the direction using methods such as <a href="#firststrong">first strong</a> or which require modification of the data itself (such as the <a href="rlm">insertion of RLM/LRM markers</a> or <a href="#paired">bidirectional controls</a>).</p>
+<p class="issue">Schema languages, such as the RDF suite of specifications, have no in-built mechanism for associating base direction metadata with natural language string values.</p>
+
+<p class="issue">There is no built-in attribute for base direction in [[JSON-LD]]. There needs to be a corresponding built-in attribute (e.g. an <q><code>@dir</code></q>) or de facto convention for indicating document-level base direction.</p>
+
+<p class="advisement" id="bp-localizable">For [[WebIDL]]-defined data structures, define each natural language text field as a <q><a>Localizable</a></q>.</p>
+
+<p> This combines both language and direction metadata and, if consistently adopted, makes interchange between different formats easier. Consistency between different specifications and document formats allows for the easy interchange of string data. By naming field attributes in the same way and adopting the same semantics, different specifications can more easily extract values from or add values into resources from other data sources.</p>
+
+
+
+<p class="advisement" id="bp-use_jsonld_context">Use of [[JSON-LD]] <code>@context</code> and the built-in <code>@language</code> attribute is RECOMMENDED as a document level default.</p>
 
 <p>For document formats that use it, [[JSON-LD]] includes some data structures that are helpful in assigning language (but not base direction) metadata to collections of strings (including entire resources). Notably, it defines what it calls <q>string internationalization</q> in the form of a context-scoped <code>@language</code> value which can be associated with blocks of JSON or within individual objects. There is no definition for base direction, so the <code>@context</code> mechanism does not currently address all concerns raised by this document.</p>
 
-<p class=req id=bp-dir-4>If metadata is not available and cannot otherwise be provided, specifications MAY allow a base direction to be <a href="#script_subtag">interpolated from available language metadata</a>.</p>
+<p class="advisement" id="bp-heuristics">If metadata is not available, consumers of strings should use heuristics, preferably based on the Unicode Standard's first-strong detection algorithm, to detect the base direction of a string.</p>
+
+<p>The <a href="#firststrong">first-strong algorithm</a> looks for the first strongly-directional character in a string (skipping certain preliminary substrings), and assumes that it represents the base direction for the string as a whole. The first strong directional character doesn't always coincide with the required base direction for the string as a whole, so it should be possible to  provide metadata, where needed, to address this problem.</p>
+
+<p class="advisement" id="bp-interpolate">If metadata is not available and cannot otherwise be provided, specifications MAY allow a base direction to be <a href="#script_subtag">interpolated from available language metadata</a>.</p>
 
 <p>Not all resources make use of the available metadata mechanisms. The script subtag of a language tag (or the "likely" script subtag based on [[BCP47]] and [[LDML]]) can sometimes be used to provide a base direction when other data is not available. Note that using language information is a "last resort" and specifications SHOULD NOT use it as the primary way of indicating direction: make the effort to provide for metadata.</p>
 
-<p class=req id=bp-dir-5>Specifications MUST NOT require the production or use of <a href="#paired">paired bidi controls</a>.</p> 
+<p class="advisement" id="bp-no_paired_bidi">Specifications MUST NOT require the production or use of <a href="#paired">paired bidi controls</a>.</p> 
 
 <p>Another way to say this is: <strong><em>do not require implementations to modify data passing through them</em></strong>. Unicode bidi control characters might be found in a particular piece of string content, where the producer or data source has used them to make the text display properly. That is, they might already be part of the data. Implementations should not disturb any controls that they find&mdash;but they shouldn't be required to produce additional controls on their own.</p>
 
-<aside class=example>
-	<p>Here is the record used in the <a href="baseExample">original example</a> with a record-level default language and base direction added. It also shows the use of a Localizable string to override the document-level defaults for the <kbd>author</kbd> field. Note that this "worked example" is not valid.</p>
+<p class="advisement" id="bp-language_indexing">Specifications SHOULD recommend the use of <a>language indexing</a> when <a>Localizable</a> strings can be supplied in multiple languages for the same value.</p>
+
+<p><a>Producers</a> sometimes need to supply multiple language values (see <a href="#localization-considerations">Localization Considerations</a>) for the same content item or data record. One use for this <a>language negotiation</a> by the <a>consumer</a>.</p>
+
+<p class="issue">[[JSON-LD]] language indexing should be modified to support the use of  <a>Localizable</a> values in <a>language indexing</a>.</p>
+
+
+
+
+<aside class="example">
+<p>Here is the record used in the <a href="baseExample">original example</a> with a record-level default language and base direction added. It also shows the use of a Localizable string to override the document-level defaults for the <kbd>author</kbd> field. Note that this "worked example" is not valid.</p>
 <pre>
 {
     "@context": { 
@@ -360,7 +375,7 @@ data in an interchange format is not a good idea. These include:</p>
         "@dir": "rtl"
     },
     "id": {"978-111887164-5"},
-    "title": "<span dir=rtl>HTML &#x0648; CSS: &#x062A;&#x0635;&#x0645;&#x064A;&#x0645; &#x0648; &#x0625;&#x0646;&#x0634;&#x0627;&#x0621; &#x0645;&#x0648;&#x0627;&#x0642;&#x0639; &#x0627;&#x0644;&#x0648;&#x064A;&#x0628;</span>",
+    "title": "<span dir="rtl">HTML &#x0648; CSS: &#x062A;&#x0635;&#x0645;&#x064A;&#x0645; &#x0648; &#x0625;&#x0646;&#x0634;&#x0627;&#x0621; &#x0645;&#x0648;&#x0627;&#x0642;&#x0639; &#x0627;&#x0644;&#x0648;&#x064A;&#x0628;</span>",
     "authors": [ {"value": "Jon Duckett", "lang": "en", "dir": "ltr"} ],
     "pubDate": "2008-01-01",
     "publisher": "&#x0645;&#x0643;&#x062A;&#x0628;&#x0629;",
@@ -369,12 +384,6 @@ data in an interchange format is not a good idea. These include:</p>
 },
 </pre>
 </aside>
-
-<p><a>Producers</a> sometimes need to supply multiple language values (see <a href="#localization-considerations">Localization Considerations</a>) for the same content item or data record. One use for this <a>language negotiation</a> by the <a>consumer</a>.</p>
-
-<p class=req id=bp-lang-5>Specifications SHOULD recommend the use of <a>language indexing</a> when <a>Localizable</a> strings can be supplied in multiple languages for the same value.</p>
-
-<p class=gap>[[JSON-LD]] language indexing should be modified to support the use of  <a>Localizable</a> values in <a>language indexing</a>.</p>
 
 </section>
 


### PR DESCRIPTION
Reorganises the material a little. 
Replaces mustard with the modern standard 'advisement' class.
Replaces the pinkstard with issues.
Add bp about first-strong heuristics.
Use quote marks around all attribute values, and add closing tags for elements.