### PR TITLE
abbreviation 'FS' is used only in this line, should be better to solve short form (and one line above is not meaningful?)

### DIFF
--- a/index.html
+++ b/index.html
@@ -320,7 +320,7 @@ data in an interchange format is not a good idea. These include:</p>
 <li>fields that set a default language and direction for all strings in that resource</li>
 <li>string-specific fields or string datatypes to specify language and direction</li>
 <li>first-strong heuristics</li>
-<li>FS heuristics augmented by directional markers at the start of the string</li>
+<li>first-strong heuristics augmented by directional markers at the start of the string</li>
 <li>string-internal markup</li>
 <li>inference of direction from special applications of language data.</li>
 </ul>


### PR DESCRIPTION
not sure this is correct fix (or say, whether to merge with one upper line?), but propose as a fix for first step.

(I may send some impression-ish comments to list instead of solid item as issue, but had some confusion around "first-strong", not on its description but on use of terms in document...)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/himorin/string-meta/pull/38.html" title="Last updated on Mar 4, 2020, 8:25 AM UTC (7a9db56)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/string-meta/38/6715548...himorin:7a9db56.html" title="Last updated on Mar 4, 2020, 8:25 AM UTC (7a9db56)">Diff</a>