### PR TITLE
possible missing comma and lang name in 3.1.2.1

### DIFF
--- a/index.html
+++ b/index.html
@@ -487,11 +487,11 @@ working on.</p>
    <p>The annotations containing the Japanese commentary have a <code class="kw" translate="no">language</code> property set to &quot;<code class="kw" translate="no">ja</code>&quot; (Japanese). The tool he is using knows that he wants to read the Japanese commentaries, and it uses this information to select and present to him the text contained in that body.  This is language information being used as metadata about the intended audience – it indicates to the application doing the retrieval that the intended consumer of the information  wants Japanese.</p>
     
    <p>Some of the annotations contain text in more than one language. 
-   For example, there are several with commentary in  Chinese, Japanese 
+   For example, there are several with commentary in  Chinese, Japanese, 
    and Tibetan. For these annotations, it's appropriate to set the 
    <code class="kw" translate="no">language</code> property to 
    &quot;<code class="kw" translate="no">ja,zh,bo</code>&quot; – 
-   indicating that both Japanese and Chinese readers may want to find 
+   indicating that all of Japanese, Chinese, and Tibetan readers may want to find 
    it.</p> <p>The language tagging that is happening here is likely to 
    be at the resource level, rather than the string level. It's 
    possible, however, that the text-processing language for strings 


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/himorin/string-meta/pull/42.html" title="Last updated on Mar 4, 2020, 6:47 PM UTC (c3d5d37)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/string-meta/42/6715548...himorin:c3d5d37.html" title="Last updated on Mar 4, 2020, 6:47 PM UTC (c3d5d37)">Diff</a>