### PR TITLE
Use the respec-w3c profile

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
 <title>Strings on the Web: Language and Direction Metadata</title>
 <meta charset="utf-8"/>
-<script src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove"></script>
+<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
 <script class="remove">
       var respecConfig = {
           // specification status (e.g. WD, LCWD, WG-NOTE, etc.). If in doubt use ED.


### PR DESCRIPTION
The `w3c-common` profile was no longer updated.
See https://github.com/w3c/respec/pull/2838 for details.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/string-meta/pull/49.html" title="Last updated on Jul 16, 2020, 8:54 AM UTC (b7dba81)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/string-meta/49/b1a6c78...b7dba81.html" title="Last updated on Jul 16, 2020, 8:54 AM UTC (b7dba81)">Diff</a>