### PR TITLE
Use the `group` configuration option

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,8 +35,7 @@
 			     ],
          
 
-          wg:           "Internationalization Working Group",
-          wgURI:         "https://www.w3.org/International/core/",
+          group:           "i18n",
           //wgPublicList: "www-international",
 		
 		  github: "w3c/string-meta",
@@ -47,7 +46,7 @@
           // This is important for Rec-track documents, do not copy a patent URI from a random
           // document unless you know what you're doing. If in doubt ask your friendly neighbourhood
           // Team Contact.
-          wgPatentURI:  "https://www.w3.org/2004/01/pp-impl/32113/status",
+          // wgPatentURI:  "https://www.w3.org/2004/01/pp-impl/32113/status",
           // !!!! IMPORTANT !!!! MAKE THE ABOVE BLINK IN YOUR HEAD
           
           		  localBiblio: {


### PR DESCRIPTION
The wg, wgId, wgURI, and wgPatentURI options are deprecated in favour of
“group”.

See https://lists.w3.org/Archives/Public/spec-prod/2020JulSep/0002.html