### PR TITLE
first cut at creating bidi keywords in string-meta

### DIFF
--- a/index.html
+++ b/index.html
@@ -167,7 +167,7 @@
 <aside class="note">
 <p>In this section [[RFC2119]] keywords in uppercase italics have their usual meaning. We differentiate <em>best practices</em>, which should be adopted by all specifications and <em>recommendations</em>, which require additional standardization or which are speculative prior to adoption.</p>
     <p class="advisement">Best practices appear with a different background color and decoration like this.</p>
-    <p>Gaps or recommendations for future work are listed as issues.</p>
+    <p class="gap">Gaps or recommendations for future work are listed as issues or displayed like this.</p>
 </aside>
 
 <p>The main issue is how to establish a common <a>serialization agreement</a> between producers and consumers of data values so that each knows how to encode, find, and interpret the language and base direction of each data field. The use of metadata for supplying both the language and base direction of natural language string fields ensures that the necessary information is present, can be supplied and extracted with the minimal amount of processing, and does not require producers or consumers to scan or alter the data.</p>
@@ -299,17 +299,43 @@
 <section>
 <h2 id="defining_bidi_keywords">Defining Bidirectional Keywords in Specifications</h2>
 
-<p>Specifications for a document format and protocol need to provide a data field or attribute to store the direction of natural language content. These definitions need to be consistent across the Web in order to ensure interoperability and this section describes how to provide such a definition along with the specific content to use.</p>
+<p>A specification for a document format or protocol that includes natural language text will need to define a data field or attribute to store the direction of that natural language content. These definitions need to be consistent across the Web in order to ensure interoperability, as <a>consumers</a> of one document format will need to map the base direction to fields in documents that they produce or control the base direction in text fields for display. This section describes how to provide such a definition along with the specific content to use.</p>
 
-<p>There are two common use cases for defining content direction: (1) metadata stored or exchanged with a natural language string giving its base direction; and (2) attribute values, particularly in document formats, used to control the display of specific content.</p>
+<p>There are two common use cases for defining content direction:</p>
 
-<p class="advisement" id="bp-define-direction-field"><a class="self" href="#bp-define-direction-field">&#x200B;</a>The base direction MUST be named either <code>direction</code> or <code>dir</code>.</p>
+<p class="definition">A <dfn data-lt="field direction value|field direction">field direction value</dfn> is a data field stored or exchanged with a natural language string giving its base direction.</p>
+<p class="definition">A <dfn data-lt="">display direction attribute</dfn> is a field or value, usually represented by an attribute in markup languages, that controls the base direction of a span of content.</p>
 
-<p>The field name <code>direction</code> is preferred for metadata. The name <code>dir</code> is preferred for an attribute, such as in markup languages. Note that both [[HTML]] and [[XML10]] have a <code>dir</code> attribute. A <code>dir</code> attribute should have scope within a document and should be defined to provide bidi isolation.</p>
+<aside class="example">
+<p><strong>Example of a <a>field direction value</a>.</strong> In this JSON fragment, the <code>title</code> structure has a value <code>direction</code> which represents the <a>field direction</a> of the <code>value</code> field.</p>
+<pre class="json">"title": {
+	"value": "HTML و CSS: تصميم و إنشاء مواقع الويب",
+	"direction": "rtl",
+	"language": "ar"
+}</pre>
 
-<p class="advisement" id="bp-define-dir-values"><a class="self" href="#bp-define-dir-values">&#x200B;</a>The values of any base direction data value MUST include and be limited to <code>ltr</code> and <code>rtl</code>. The values of any base direction attribute MUST include and be limited to the values <code>ltr</code>, <code>rtl</code>, and <code>auto</code>.</p>
+<p><strong>Example of a <a>display direction attribute</a>.</strong> If the above JSON were received by a process that was assembling a Web page for display, it might be filling in a template similar to the top line in this example. Here the <code>dir</code> attribute from [[HTML]] is an example of a <a>display direction attribute</a>.</p>
 
-<p class="advisement" id="bp-dir-auto-non-use"><a class="self" href="#bp-dir-auto-non-use">&#x200B;</a>The value <code>auto</code> SHOULD NOT be used as metadata: omitting the direction is preferred when the content direction is not known.</p>
+<pre class="html">
+&lt;p dir={$dir}>{$title}&lt;/p>
+&lt;p dir="rtl">HTML و CSS: تصميم و إنشاء مواقع الويب&lt;/p>
+</pre>
+	
+</aside>
+
+<p class="advisement" id="bp-define-field-direction-value"><a class="self" href="#bp-define-field-direction-value">&#x200B;</a>Use the field name <code>direction</code> when defining a <a>field direction value</a>.</p>
+
+<p>The name <code>direction</code> is preferred for data values. The name <code>dir</code> is an acceptable alternative.</p>
+
+<p class="advisement" id="bp-define-display-dir-attribute"><a class="self" href="#bp-define-display-dir-attribute">&#x200B;</a>Use the field name <code>dir</code> when defining a <a>display direction attribute</a>.</p>
+
+<p>The name <code>dir</code> is preferred for an attribute, such as in markup languages. Using <code>direction</code> for an attribute is not recommended, since it is long and relatively uncommon for this use case. Note that both [[HTML]] and [[XML10]] have a built-in <code>dir</code> attribute. A <code>dir</code> attribute should have scope within a document and should be defined to provide bidi isolation.</p>
+
+<p class="advisement" id="bp-define-direction-values"><a class="self" href="#bp-define-direction-values">&#x200B;</a>Define the values of a <a>field direction</a> to include and be limited to <code>ltr</code> and <code>rtl</code>.</p>
+
+<p class="advisement" id="bp-define-dir-attribute-values"><a class="self" href="#bp-define-dir-attribute-values">&#x200B;</a> Define the values of any <a>display direction attribute</a> to include and be limited to the values <code>ltr</code>, <code>rtl</code>, and <code>auto</code>.</p>
+
+<p class="advisement" id="bp-dir-auto-non-use"><a class="self" href="#bp-dir-auto-non-use">&#x200B;</a>The value <code>auto</code> SHOULD NOT be used as <a>field direction value</a>: omitting the direction is preferred when the content direction is not known.</p>
 
 <p>The value <code>ltr</code> indicates a base direction of left-to-right, in exactly the same manner indicated by <a href="https://www.w3.org/TR/css-writing-modes/#direction">CSS writing modes</a> [[CSS-WRITING-MODES-4]]</p>
 

--- a/index.html
+++ b/index.html
@@ -297,13 +297,19 @@
 </section>
 
 <section>
-<h2 id="defining_bidi_attributes">Defining Bidirectional Attributes in Specifications</h2>
+<h2 id="defining_bidi_keywords">Defining Bidirectional Keywords in Specifications</h2>
 
-<p>Specifications for document formats and protocols sometimes need to define the direction attribute and its values. These definitions need to be consistent across the Web in order to ensure interoperability.</p>
+<p>Specifications for a document format and protocol need to provide a data field or attribute to store the direction of natural language content. These definitions need to be consistent across the Web in order to ensure interoperability and this section describes how to provide such a definition along with the specific content to use.</p>
 
-<p>Define the base direction attribute using the name <code>direction</code> or the name <code>dir</code>. Use <code>direction</code> for data values in a data structure. Use <code>dir</code> for attribute values, such as in markup languages.</p>
+<p>There are two common use cases for defining content direction: (1) metadata stored or exchanged with a natural language string giving its base direction; and (2) attribute values, particularly in document formats, used to control the display of specific content.</p>
 
-<p>The values of the base direction data value or attribute MUST include <code>ltr</code> and <code>rtl</code>. The values MAY also include the value <code>auto</code> when that is appropriate.</p>
+<p class="advisement" id="bp-define-direction-field"><a class="self" href="#bp-define-direction-field">&#x200B;</a>The base direction MUST be named either <code>direction</code> or <code>dir</code>.</p>
+
+<p>The field name <code>direction</code> is preferred for metadata. The name <code>dir</code> is preferred for an attribute, such as in markup languages. Note that both [[HTML]] and [[XML10]] have a <code>dir</code> attribute. A <code>dir</code> attribute should have scope within a document and should be defined to provide bidi isolation.</p>
+
+<p class="advisement" id="bp-define-dir-values"><a class="self" href="#bp-define-dir-values">&#x200B;</a>The values of any base direction data value MUST include and be limited to <code>ltr</code> and <code>rtl</code>. The values of any base direction attribute MUST include and be limited to the values <code>ltr</code>, <code>rtl</code>, and <code>auto</code>.</p>
+
+<p class="advisement" id="bp-dir-auto-non-use"><a class="self" href="#bp-dir-auto-non-use">&#x200B;</a>The value <code>auto</code> SHOULD NOT be used as metadata: omitting the direction is preferred when the content direction is not known.</p>
 
 <p>The value <code>ltr</code> indicates a base direction of left-to-right, in exactly the same manner indicated by <a href="https://www.w3.org/TR/css-writing-modes/#direction">CSS writing modes</a> [[CSS-WRITING-MODES-4]]</p>
 
@@ -312,8 +318,6 @@
 <p>The value <code>auto</code> indicates that the user agent uses the first strong character of the content to determine the base direction using the <a href="https://html.spec.whatwg.org/multipage/dom.html#the-dir-attribute">algorithm</a> for <code>auto</code> found in [[HTML]].</p>
 
 <p class="note">The heuristic used by <code>auto</code> just looks at the first character with a strong directionality, in a manner analogous to the Paragraph Level determination in the bidirectional algorithm [[UAX9]]. Authors are urged to only use this value as a last resort when the direction of the text is truly unknown and no better server-side heuristic can be applied.</p>
-
-<p>The value <code>auto</code> is only appropriate for presentation, not as metadata about the direction of content. When the direction of content is not known, omitting the <code>direction</code> attribute is preferred.</p>
 
 </section>
 

--- a/index.html
+++ b/index.html
@@ -295,6 +295,28 @@
 </pre>
 </aside>
 </section>
+
+<section>
+<h2 id="defining_bidi_attributes">Defining Bidirectional Attributes in Specifications</h2>
+
+<p>Specifications for document formats and protocols sometimes need to define the direction attribute and its values. These definitions need to be consistent across the Web in order to ensure interoperability.</p>
+
+<p>Define the base direction attribute using the name <code>direction</code> or the name <code>dir</code>. Use <code>direction</code> for data values in a data structure. Use <code>dir</code> for attribute values, such as in markup languages.</p>
+
+<p>The values of the base direction data value or attribute MUST include <code>ltr</code> and <code>rtl</code>. The values MAY also include the value <code>auto</code> when that is appropriate.</p>
+
+<p>The value <code>ltr</code> indicates a base direction of left-to-right, in exactly the same manner indicated by <a href="https://www.w3.org/TR/css-writing-modes/#direction">CSS writing modes</a> [[CSS-WRITING-MODES-4]]</p>
+
+<p>The value <code>rtl</code> indicates a base direction of right-to-left, in exactly the same manner indicated by <a href="https://www.w3.org/TR/css-writing-modes/#direction">CSS writing modes</a> [[CSS-WRITING-MODES-4]]</p>
+
+<p>The value <code>auto</code> indicates that the user agent uses the first strong character of the content to determine the base direction using the <a href="https://html.spec.whatwg.org/multipage/dom.html#the-dir-attribute">algorithm</a> for <code>auto</code> found in [[HTML]].</p>
+
+<p class="note">The heuristic used by <code>auto</code> just looks at the first character with a strong directionality, in a manner analogous to the Paragraph Level determination in the bidirectional algorithm [[UAX9]]. Authors are urged to only use this value as a last resort when the direction of the text is truly unknown and no better server-side heuristic can be applied.</p>
+
+<p>The value <code>auto</code> is only appropriate for presentation, not as metadata about the direction of content. When the direction of content is not known, omitting the <code>direction</code> attribute is preferred.</p>
+
+</section>
+
 </section>
 
 <section>

--- a/local.css
+++ b/local.css
@@ -59,7 +59,7 @@ p.cjk-demo {
 }
 
 .gap::before {
-    content: "\1f631 \00A0 ";
+    content: "\2757 \fe0f \00A0 ";
     font-style: normal;
     color: #63F;;
 }
@@ -109,4 +109,14 @@ a.self:hover {
 
 .advisement {
     position: relative;
+}
+
+.definition {
+    position: relative;
+    background-color: #efefef;
+    padding: 0.5em;
+    border: 0.5em;
+    border-left: 6pt solid green;
+    border-right: 6pt solid green;
+    margin: 1em auto;
 }


### PR DESCRIPTION
@r12a Work is needed here, but I thought I'd get initial thoughts. I thought about using more mustard-y best practices and providing canned definitions to quote. And I wasn't sure about the value-vs.-attribute bits. Have a look and see what you think.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/aphillips/string-meta/pull/55.html" title="Last updated on Jun 17, 2021, 9:59 PM UTC (d296c7e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/string-meta/55/4dfb113...aphillips:d296c7e.html" title="Last updated on Jun 17, 2021, 9:59 PM UTC (d296c7e)">Diff</a>