### PR TITLE
Reorganise the Best Practices section

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,9 +8,9 @@
       var respecConfig = {
           // specification status (e.g. WD, LCWD, WG-NOTE, etc.). If in doubt use ED.
           specStatus:           "ED",
-          //publishDate:  	"2019-04-16",
-          //previousPublishDate: "2019-04-16",
-          //previousMaturity:  	"WD",
+          //publishDate:  		"2019-04-16",
+          //previousPublishDate:  "2019-04-16",
+          //previousMaturity:  	 "WD",
 
 
           noRecTrack:           true,
@@ -174,13 +174,13 @@
 
 
 <div class="req" id="bp_not_only_default">
-<p class="advisement">Specifications MUST NOT assume that a document-level default is sufficient.  Even If a resource-wide setting is available, specify field-based metadata to override the default.</p>
+<p class="advisement">Specifications MUST NOT assume that a resource-wide default is sufficient.  Even if a resource-wide setting is available, it must be possible to use string-specific metadata  to override that default.</p>
 </div>
 
 
 <p>Document level defaults, when combined with per-field metadata, can reduce the overall complexity of a given document instance, since the language and direction values don't have to be repeated across many fields. However, they do not solve all language or directionality problems, and so it must be possible to override the default on a string-by-string basis, where necessary.</p>
 
-<p>First-strong heuristics are ineffective when a default direction has been set for all strings, since  metadata overrides (intentionally) the value of the first-strong character. Therefore it is necessary to use explicitly provided field data to override the default. Even if an RLM character has been prepended to a string, the default metadata overrides it.</p>
+<p>First-strong heuristics are ineffective when a default direction has been set for all strings, since metadata overrides (intentionally) the value of the first-strong character. Therefore it is necessary to use explicitly provided field data to override the default. Even if an RLM character has been prepended to a string, the default metadata overrides it.</p>
 
 
 <div class="req" id="bp_lang_field_based_metadata">
@@ -194,7 +194,7 @@
     <p>For example, [[JSON-LD]] provides a document-level base direction using the <code>@context</code> mechanism and defines the <code>i18n</code> namespace as an extension of existing RDF datatypes which can be used to set the language and/or base direction of string values.</p>
 </aside>
 
-<p> Low-level support for <a>natural language</a> string metadata is widespread because the use of metadata for storage and interchange of the language of data values is long-established and widely supported in the basic infrastructure of the Web. This includes language attributes in [[XML]] and [[HTML]]; string types in schema languages (e.g. [[xmlschema11-2]]) or the various RDF specifications including [[JSON-LD]]; or protocol- or document format-specific provisions for language.</p>
+<p>Low-level support for <a>natural language</a> string metadata is widespread because the use of metadata for storage and interchange of the language of data values is long-established and widely supported in the basic infrastructure of the Web. This includes language attributes in [[XML]] and [[HTML]]; string types in schema languages (e.g. [[xmlschema11-2]]) or the various RDF specifications including [[JSON-LD]]; or protocol- or document format-specific provisions for language.</p>
 
 
 <div class="req" id="bp_default_fallback">

--- a/index.html
+++ b/index.html
@@ -159,8 +159,56 @@
 </ul>
 <p>The use of some of the above preclude the use of others, and in some cases some of the above approaches may need to be specified together to cater for fallback situations.</p>
 
+
+
+
+
+
 <section>
-<h3 id="general_bps">General best practices</h3>
+<h3 id="resource_wide_defaults">Resource-wide &amp; string-specific defaults</h3>
+<p>Many resources use only a single language and have a consistent base text direction. For efficiency, the following are best practices:</p>
+
+<div class="req" id="bp_default_setting">
+<p class="advisement">Define a rule or a field to provide the default language and base direction for all strings in a given resource.</p>
+</div>
+
+
+<div class="req" id="bp_not_only_default">
+<p class="advisement">Specifications MUST NOT assume that a document-level default is sufficient.  Even If a resource-wide setting is available, specify field-based metadata to override the default.</p>
+</div>
+
+
+<p>Document level defaults, when combined with per-field metadata, can reduce the overall complexity of a given document instance, since the language and direction values don't have to be repeated across many fields. However, they do not solve all language or directionality problems, and so it must be possible to override the default on a string-by-string basis, where necessary.</p>
+
+<p>First-strong heuristics are ineffective when a default direction has been set for all strings, since  metadata overrides (intentionally) the value of the first-strong character. Therefore it is necessary to use explicitly provided field data to override the default. Even if an RLM character has been prepended to a string, the default metadata overrides it.</p>
+
+
+<div class="req" id="bp_lang_field_based_metadata">
+<p class="advisement">Use field-based metadata or string datatypes to indicate the language and the base direction for individual <a>localizable text</a> values.</p>
+</div>
+
+<p>The use of <a href="#metadata">metadata</a> for indicating base direction is  preferred because it avoids requiring the consumer to interpolate the direction using methods such as <a href="#firststrong">first strong</a> or use of methods which require modification of the data itself (such as the <a href="#rlm">insertion of RLM/LRM markers</a> or <a href="#paired">bidirectional controls</a>).</p>
+
+<aside class="note">
+    <p>Some schema languages, such as the RDF suite of specifications, have no built-in mechanism for associating base direction metadata with natural language string values. It is up to specifications that use these specifications to define structures and adopt best practices that result in clean interchange of language and direction metadata.</p>
+    <p>For example, [[JSON-LD]] provides a document-level base direction using the <code>@context</code> mechanism and defines the <code>i18n</code> namespace as an extension of existing RDF datatypes which can be used to set the language and/or base direction of string values.</p>
+</aside>
+
+<p> Low-level support for <a>natural language</a> string metadata is widespread because the use of metadata for storage and interchange of the language of data values is long-established and widely supported in the basic infrastructure of the Web. This includes language attributes in [[XML]] and [[HTML]]; string types in schema languages (e.g. [[xmlschema11-2]]) or the various RDF specifications including [[JSON-LD]]; or protocol- or document format-specific provisions for language.</p>
+
+
+<div class="req" id="bp_default_fallback">
+<p class="advisement">Specify that, in the absence of other information, the default direction and default language are unknown.</p>
+</div>
+
+<p>Explicit metadata, if available, trumps the need for heuristics to be applied.  This is logical, since the heuristic method cannot reliably deduce the necessary direction on its own, and if metadata has been explicitly provided there is an indication that it is intended to be authoritative.
+</p>
+<p>It is essential for a consumer to know that language and direction are unknown quantities in order for them to know when to apply fallback strategies to the data (this could include language-detection, or first-strong heuristics for direction).  In particular, the default direction should not be set to LTR, since that would override the need for first-strong detection, which is more appropriate for strings written in a RTL script.</p>
+</section>
+
+
+<section>
+<h3 id="string_specific_language">String-specific language information</h3>
 
 <div class="req" id="bp_separate_localizable">
 <p class="advisement">Specifications SHOULD be careful to distinguish <a>syntactic content</a>, including <a>user-supplied values</a>, from <a>localizable text</a>.</p>
@@ -177,72 +225,6 @@
    <p>Error messages are not syntactic content. They consist of and should be treated as <a>localizable text</a>.</p>
 </aside>
 
-<div class="req" id="bp_unicode_tag_chars_nonuse">
-<p class="advisement">Specifications SHOULD NOT use the Unicode "language tag" characters (code points <code>U+E0000</code> to <code>U+E007F</code>) for language identification.</p>
-
-<p>[[Unicode]] says that the <q>... use of tag characters to convey language tags is strongly discouraged</q> and that the use of the character <span class="uname">U+E0001 LANGUAGE TAG</span> is <em>strongly discouraged</em>.</p>
-</div>
-
-
-</section>
-
-<section>
-<h3 id="resource_wide_defaults">Resource-wide defaults</h3>
-<p>Many resources use only a single language and have a consistent base text direction. For efficiency, the following are best practices:</p>
-
-<div class="req" id="bp_default_setting">
-<p class="advisement">Define a rule or a field to provide the default language and base direction for all strings in a given resource.</p>
-</div>
-
-
-<div class="req" id="bp_not_only_default">
-<p class="advisement">Specifications MUST NOT assume that a document-level default is sufficient.</p>
-</div>
-
-
-<p>Document level defaults, when combined with per-field metadata, can reduce the overall complexity of a given document instance, since the language and direction values don't have to be repeated across many fields. However, they do not solve all language or directionality problems, and so it must be possible to override the default on a string-by-string basis, where necessary.</p>
-
-<div class="req" id="bp_default_fallback">
-<p class="advisement">Specify that, in the absence of other information, the default direction and default language are unknown.</p>
-</div>
-
-<p>Explicit metadata, if available, trumps the need for heuristics to be applied.  This is logical, since the heuristic method cannot reliably deduce the necessary direction on its own, and if metadata has been explicitly provided there is an indication that it is intended to be authoritative.
-</p>
-<p>It is essential for a consumer to know that language and direction are unknown quantities in order for them to know when to apply fallback strategies to the data (this could include language-detection, or first-strong heuristics for direction).  In particular, the default direction should not be set to LTR, since that would override the need for first-strong detection, which is more appropriate for strings written in a RTL script.</p>
-
-
-<div class="req" id="bp_use_jsonld_language_context">
-<p class="advisement">Use of [[JSON-LD]] <code class="kw" translate="no">@context</code> and the built-in <code class="kw" translate="no">@language</code> attribute is RECOMMENDED as a document level default.</p>
-</div>
-
-
-<p>For document formats that use it, [[JSON-LD]] includes some data structures that are helpful in assigning language (but not base direction) metadata to collections of strings (including entire resources). Notably, it defines what it calls “string internationalization” in the form of a context-scoped <code class="kw" translate="no">@language</code> value which can be associated with blocks of JSON or within individual objects. There is no definition for base direction, so the <code class="kw" translate="no">@context</code> mechanism does not currently address all concerns raised by this document.</p>
-</section>
-
-
-<section>
-<h3 id="string_specific_language">String-specific language information</h3>
-
-<div class="req" id="bp_lang_field_based_metadata">
-<p class="advisement">Use field-based metadata or string datatypes to indicate the language and the base direction for individual <a>localizable text</a> values.</p>
-</div>
-
-<p> Low-level support for <a>natural language</a> string metadata is widespread because the use of metadata for storage and interchange of the language of data values is long-established and widely supported in the basic infrastructure of the Web. This includes language attributes in [[XML]] and [[HTML]]; string types in schema languages (e.g. [[xmlschema11-2]]) or the various RDF specifications including [[JSON-LD]]; or protocol- or document format-specific provisions for language.</p>
-
-<div class="req" id="bp-use_jsonld_i18n_namespace">
-	<p class="advisement">Specifications SHOULD use the <code>i18n</code> Namespace feature for RDF literals, as defined in [[JSON-LD]] 1.1.</p>
-</div>
-
-<div class="req" id="bp_use_jsonld_atsign">
-<p class="advisement">Where the <code>i18n</code> Namespace is not available or is inappropriate to use, specifications SHOULD require [[JSON-LD]] plain string literals for natural language values to provide string-specific language information.</p>
-</div>
-
-<p>Some datatypes, such as [[RDF-PLAIN-LITERAL]], already exist that allow for <em>language</em> metadata to be serialized as part of a string value. Examples include:</p>
-<div class="example">
-<p>&quot;title&quot;: &quot;تصميم و إنشاء مواقع الويب@ar&quot;,</p>
-<p> &quot;tags&quot;: [ &quot;HTML@en&quot;, &quot;CSS@en&quot;, &quot;تصميم المواقع@ar&quot; ]</p>
-<p>&quot;id&quot;: &quot;978-111887164-5@und&quot;</p>
-</div>
 
 <div class="req" id="bp-do_not_use_language_non_data">
 	<p class="advisement">Specifications SHOULD NOT specify or require the use of language metadata for fields that cannot contain natural language text.</p>
@@ -268,32 +250,15 @@
 <section>
 <h3 id="string_specific_direction">String-specific directional information</h3>
 
-<div class="req" id="dir_field_based_metadata">
-<p class="advisement">If a resource-wide setting is available, specify field-based metadata to override the default. </p>
-</div>
-
-
-<p>First-strong heuristics are ineffective when a default direction has been set for all strings, since  metadata overrides (intentionally) the value of the first-strong character. Therefore it is necessary to use explicitly provided field data to override the default. Even if an RLM character has been prepended to a string, the default metadata overrides it.</p>
-<p>The use of <a href="#metadata">metadata</a> for indicating base direction is also preferred, because it avoids requiring the consumer to interpolate the direction using methods such as <a href="#firststrong">first strong</a> or use of methods which require modification of the data itself (such as the <a href="#rlm">insertion of RLM/LRM markers</a> or <a href="#paired">bidirectional controls</a>).</p>
-
-<div class="note">
-    <p>Some schema languages, such as the RDF suite of specifications, have no built-in mechanism for associating base direction metadata with natural language string values. It is up to specifications that use these specifications to define structures and adopt best practices that result in clean interchange of language and direction metadata.</p>
-    <p>For example, [[JSON-LD]] provides a document-level base direction using the <code>@context</code> mechanism and defines the <code>i18n</code> namespace as an extension of existing RDF datatypes which can be used to set the language and/or base direction of string values.</p>
-</div>
-
 <div class="req" id="bp_use_heuristics_1">
-<p class="advisement">For the case where the resource-wide setting is not available, specify that consumers should use first-strong heuristics to identify the base direction of strings.</p>
-</div>
-
-<div class="req" id="bp_use_heuristics_2">
-<p class="advisement">For the case where the resource-wide setting is available but not used, specify that consumers should fall back to first-strong heuristics to identify the base direction of strings.</p>
+<p class="advisement">For the case where the direction is not known, specify that consumers should use first-strong heuristics to identify the base direction of strings.</p>
 </div>
 
 <p>If metadata is not available, consumers of strings should use heuristics, preferably based on the Unicode Standard's first-strong detection algorithm, to detect the base direction of a string.</p>
 <p>The <a href="#firststrong">first-strong algorithm</a> looks for the first strongly-directional character in a string (skipping certain preliminary substrings), and assumes that it represents the base direction for the string as a whole. However, the first strong directional character doesn't always coincide with the required base direction for the string as a whole, so it should be possible to  provide metadata, where needed, to address this problem.</p>
 
 <div class="req" id="bp_using_rlm_lrm">
-<p class="advisement">If relying on first-strong heuristics, encourage content developers to use RLM/LRM at the beginning of a string where it is necessary to force a particular base direction, but do not prepend one of these characters to existing strings.</p>
+<p class="advisement">If relying on first-strong heuristics, allow content developers to use RLM/LRM at the beginning of a string where it is necessary to force a particular base direction, but do not prepend one of these characters to existing strings.</p>
 </div>
 
 <div class="req" id="bp_rlm_lrm_availability">
@@ -301,30 +266,75 @@
 </div>
 
 <p>If string data is being provided by users or content developers in web forms or other simple environments, users may not be able to enter these formatting characters.  In fact, most users will probably be unaware that such characters exist, or how to use them.  A web form can render their use unnecessary for immediate inspection if it sets the base direction for the input (which it should).</p>
-
-<div class="req" id="bp_inferring_from_language">
-<p class="advisement">Specifications SHOULD NOT allow a base direction to be <a href="#script_subtag">interpolated from available language metadata</a> unless direction metadata is not available and cannot otherwise be provided.</p>
-</div>
-
-<p>Not all resources make use of the available metadata mechanisms. The script subtag of a language tag (or the "likely" script subtag based on [[BCP47]] and [[LDML]]) can sometimes be used to provide a base direction when other data is not available. Note that using language information is a "last resort" and specifications SHOULD NOT use it as the primary way of indicating direction: make the effort to provide for metadata.</p>
 </section>
 
 
 
+
+
 <section>
-<h3 id="other_approaches">Other approaches</h3>
+<h3 id="technology_specific_solutions">Technology-specific solutions</h3>
+
+<div class="req" id="bp_use_jsonld_language_context">
+<p class="advisement">Use of [[JSON-LD]] <code class="kw" translate="no">@context</code> and the built-in <code class="kw" translate="no">@language</code> attribute is RECOMMENDED as a document level default.</p>
+</div>
+
+
+<p>For document formats that use it, [[JSON-LD]] includes some data structures that are helpful in assigning language (but not base direction) metadata to collections of strings (including entire resources). Notably, it defines what it calls “string internationalization” in the form of a context-scoped <code class="kw" translate="no">@language</code> value which can be associated with blocks of JSON or within individual objects. There is no definition for base direction, so the <code class="kw" translate="no">@context</code> mechanism does not currently address all concerns raised by this document.</p>
+
+
+<div class="req" id="bp-use_jsonld_i18n_namespace">
+	<p class="advisement">Specifications SHOULD use the <code>i18n</code> Namespace feature for RDF literals, as defined in [[JSON-LD]] 1.1.</p>
+</div>
+
+<div class="req" id="bp_use_jsonld_atsign">
+<p class="advisement">Where the <code>i18n</code> Namespace is not available or is inappropriate to use, specifications SHOULD require [[JSON-LD]] plain string literals for natural language values to provide string-specific language information.</p>
+</div>
+
+<p>Some datatypes, such as [[RDF-PLAIN-LITERAL]], already exist that allow for <em>language</em> metadata to be serialized as part of a string value. Examples include:</p>
+<div class="example">
+<p>&quot;title&quot;: &quot;تصميم و إنشاء مواقع الويب@ar&quot;,</p>
+<p> &quot;tags&quot;: [ &quot;HTML@en&quot;, &quot;CSS@en&quot;, &quot;تصميم المواقع@ar&quot; ]</p>
+<p>&quot;id&quot;: &quot;978-111887164-5@und&quot;</p>
+</div>
+
 
 <div class="req" id="bp_localizable">
 <p class="advisement">For [[WebIDL]]-defined data structures, define each <a>localizable text</a> (natural language text) field as a <q><a>Localizable</a></q>.</p>
 </div>
 
 <p> This combines both language and direction metadata and, if consistently adopted, makes interchange between different formats easier. Consistency between different specifications and document formats allows for the easy interchange of string data. By naming field attributes in the same way and adopting the same semantics, different specifications can more easily extract values from or add values into resources from other data sources.</p>
+</section>
+
+
+
+
+
+<section>
+<h3 id="other_approaches">Other approaches</h3>
+
+<div class="req" id="bp_unicode_tag_chars_nonuse">
+<p class="advisement">Specifications SHOULD NOT use the Unicode "language tag" characters (code points <code>U+E0000</code> to <code>U+E007F</code>) for language identification.</p>
+</div>
+
+<p>[[Unicode]] says that the <q>... use of tag characters to convey language tags is strongly discouraged</q> and that the use of the character <span class="uname">U+E0001 LANGUAGE TAG</span> is <em>strongly discouraged</em>.</p>
+
+
 
 <div class="req" id="bp_no_paired_bidi">
 <p class="advisement">Specifications MUST NOT require the production or use of <a href="#paired">paired bidi controls</a>.</p>
 </div>
 
 <p>Another way to say this is: <strong><em>do not require implementations to modify data passing through them</em></strong>. Unicode bidi control characters might be found in a particular piece of string content, where the producer or data source has used them to make the text display properly. That is, they might already be part of the data. Implementations should not disturb any controls that they find&mdash;but they shouldn't be required to produce additional controls on their own.</p>
+
+
+
+<div class="req" id="bp_inferring_from_language">
+<p class="advisement">Specifications SHOULD NOT allow a base direction to be <a href="#script_subtag">interpolated from available language metadata</a> unless direction metadata is not available and cannot otherwise be provided.</p>
+</div>
+
+<p>Not all resources make use of the available metadata mechanisms. The script subtag of a language tag (or the "likely" script subtag based on [[BCP47]] and [[LDML]]) can sometimes be used to provide a base direction when other data is not available. Note that using language information is a "last resort" and specifications SHOULD NOT use it as the primary way of indicating direction: make the effort to provide for metadata.</p>
+
 
 <div class="req" id="bp_language_indexing">
 <p class="advisement">Specifications SHOULD recommend the use of <a>language indexing</a> when <a>Localizable</a> strings can be supplied in multiple languages for the same value.</p>

--- a/index.html
+++ b/index.html
@@ -8,8 +8,8 @@
       var respecConfig = {
           // specification status (e.g. WD, LCWD, WG-NOTE, etc.). If in doubt use ED.
           specStatus:           "ED",
-          //publishDate:  		"2019-04-16",
-          //previousPublishDate:  "2019-04-16",
+          //publishDate:  	"2019-04-16",
+          //previousPublishDate: "2019-04-16",
           //previousMaturity:  	"WD",
 
 


### PR DESCRIPTION
I've been struggling with this section for a long time.  I finally sat down and thought through how we could make it read better, and reduce duplication.  This is my proposal.

I mostly just moved things around.  There is only a very small amount of text change.  It will probably be necessary to go through the text one more time to ensure that the narrative flows well.

I think this makes it easier to grock the key recommendations, and reduces previous duplications which were a little confusing.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/string-meta/pull/67.html" title="Last updated on Jul 26, 2022, 10:18 AM UTC (e57164a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/string-meta/67/c94d854...e57164a.html" title="Last updated on Jul 26, 2022, 10:18 AM UTC (e57164a)">Diff</a>