### PR TITLE
Rewrite of initial recommendations in guidelines

### DIFF
--- a/index.html
+++ b/index.html
@@ -172,7 +172,7 @@
 </div>
 
 
-<p>Use of heuristics to determine language and direction will always fail for certain  cases, and there needs to be a way to override the outcome for those cases. Assignment of <a href="#metadata">metadata</a> (either as a resource-wide default, or in a string-specific label) is an intentional act that overrides the need to  guess the outcome by applying heuristics.</p>
+<p>Use of heuristics to determine language or base direction will always fail for certain cases, and there needs to be a way to provide the correct outcome for those cases. Assignment of <a href="#metadata">metadata</a> (either as a resource-wide default, or in a string-specific label) is an intentional act that removes the need to guess the outcome by applying heuristics.</p>
 
 <p>The use of <a href="#metadata">metadata</a> for indicating base direction is  preferred because it avoids requiring the consumer to interpolate the direction using methods such as <a href="#firststrong">first strong</a> or use of methods which require modification of the data itself (such as the <a href="#rlm">insertion of RLM/LRM markers</a> or <a href="#paired">bidirectional controls</a>).</p>
 
@@ -186,14 +186,14 @@
 
 
 <div class="req" id="bp_default_setting">
-<p class="advisement">Specifications MAY define a rule or a field to provide the default language and base direction for all strings in a given resource. However, specifications MUST NOT assume that a resource-wide default is sufficient.  Even if a resource-wide setting is available, it must be possible to use string-specific metadata  to override that default.</p>
+<p class="advisement">Specifications MAY define a mechanism to provide the default language and the default base direction for all strings in a given resource. However, specifications MUST NOT assume that a resource-wide default is sufficient.  Even if a resource-wide setting is available, it must be possible to use string-specific metadata  to override that default.</p>
 </div>
 
-<p>Resource-wide defaults are particularly useful for increasing efficiency for any resources that use only a single language and have a consistent base text direction. It also reduces the overall complexity of a given document instance, since the language and direction values don't have to be repeated across many fields.</p>
+<p>Resource-wide defaults are particularly useful for increasing efficiency for any resources that use only a single language or have a consistent base text direction. It also reduces the overall complexity of a given document instance, since the language and direction values don't have to be repeated across many fields.</p>
 
 <p>However, there will always be exceptions to the default, and so it must be possible to override the default on a string-by-string basis, where necessary.</p>
 
-<p> First-strong heuristics are not applied to strings when the direction has been set externally using metadata. Even if an RLM character has been prepended to a string, the default metadata overrides it. Therefore it is necessary to use explicitly provided field data to override the default for strings whose base direction does not match the resource-wide default.</p>
+<p>First-strong heuristics are not applied to strings when the direction has been set externally using metadata. Even if an RLM character has been prepended to a string, the default metadata overrides it when determining the base direction of the string. Therefore it is necessary to use explicitly provided field data to override the default for strings whose base direction does not match the resource-wide default.</p>
 
 
 

--- a/index.html
+++ b/index.html
@@ -172,7 +172,7 @@
 </div>
 
 
-<p>Use of heuristics to determine language or base direction will always fail for certain cases, and there needs to be a way to provide the correct outcome for those cases. Assignment of <a href="#metadata">metadata</a> (either as a resource-wide default, or in a string-specific label) is an intentional act that removes the need to guess the outcome by applying heuristics.</p>
+<p>Use of heuristics to determine language or base direction will always fail for certain cases, and there needs to be a way to provide the correct outcome for those strings. Assignment of <a href="#metadata">metadata</a> (either as a resource-wide default, or in a string-specific label) is an intentional act that removes the need to guess the outcome by applying heuristics.</p>
 
 <p>The use of <a href="#metadata">metadata</a> for indicating base direction is  preferred because it avoids requiring the consumer to interpolate the direction using methods such as <a href="#firststrong">first strong</a> or use of methods which require modification of the data itself (such as the <a href="#rlm">insertion of RLM/LRM markers</a> or <a href="#paired">bidirectional controls</a>).</p>
 

--- a/index.html
+++ b/index.html
@@ -165,27 +165,14 @@
 
 
 <section>
-<h3 id="resource_wide_defaults">Resource-wide &amp; string-specific defaults</h3>
-<p>Many resources use only a single language and have a consistent base text direction. For efficiency, the following are best practices:</p>
-
-<div class="req" id="bp_default_setting">
-<p class="advisement">Define a rule or a field to provide the default language and base direction for all strings in a given resource.</p>
-</div>
-
-
-<div class="req" id="bp_not_only_default">
-<p class="advisement">Specifications MUST NOT assume that a resource-wide default is sufficient.  Even if a resource-wide setting is available, it must be possible to use string-specific metadata  to override that default.</p>
-</div>
-
-
-<p>Document level defaults, when combined with per-field metadata, can reduce the overall complexity of a given document instance, since the language and direction values don't have to be repeated across many fields. However, they do not solve all language or directionality problems, and so it must be possible to override the default on a string-by-string basis, where necessary.</p>
-
-<p>First-strong heuristics are ineffective when a default direction has been set for all strings, since metadata overrides (intentionally) the value of the first-strong character. Therefore it is necessary to use explicitly provided field data to override the default. Even if an RLM character has been prepended to a string, the default metadata overrides it.</p>
-
+<h3 id="resource_wide_defaults">Resource-wide defaults and string-specific metadata</h3>
 
 <div class="req" id="bp_lang_field_based_metadata">
 <p class="advisement">Use field-based metadata or string datatypes to indicate the language and the base direction for individual <a>localizable text</a> values.</p>
 </div>
+
+
+<p>Use of heuristics to determine language and direction will always fail for certain  cases, and there needs to be a way to override the outcome for those cases. Assignment of <a href="#metadata">metadata</a> (either as a resource-wide default, or in a string-specific label) is an intentional act that overrides the need to  guess the outcome by applying heuristics.</p>
 
 <p>The use of <a href="#metadata">metadata</a> for indicating base direction is  preferred because it avoids requiring the consumer to interpolate the direction using methods such as <a href="#firststrong">first strong</a> or use of methods which require modification of the data itself (such as the <a href="#rlm">insertion of RLM/LRM markers</a> or <a href="#paired">bidirectional controls</a>).</p>
 
@@ -195,6 +182,19 @@
 </aside>
 
 <p>Low-level support for <a>natural language</a> string metadata is widespread because the use of metadata for storage and interchange of the language of data values is long-established and widely supported in the basic infrastructure of the Web. This includes language attributes in [[XML]] and [[HTML]]; string types in schema languages (e.g. [[xmlschema11-2]]) or the various RDF specifications including [[JSON-LD]]; or protocol- or document format-specific provisions for language.</p>
+
+
+
+<div class="req" id="bp_default_setting">
+<p class="advisement">Specifications MAY define a rule or a field to provide the default language and base direction for all strings in a given resource. However, specifications MUST NOT assume that a resource-wide default is sufficient.  Even if a resource-wide setting is available, it must be possible to use string-specific metadata  to override that default.</p>
+</div>
+
+<p>Resource-wide defaults are particularly useful for increasing efficiency for any resources that use only a single language and have a consistent base text direction. It also reduces the overall complexity of a given document instance, since the language and direction values don't have to be repeated across many fields.</p>
+
+<p>However, there will always be exceptions to the default, and so it must be possible to override the default on a string-by-string basis, where necessary.</p>
+
+<p> First-strong heuristics are not applied to strings when the direction has been set externally using metadata. Even if an RLM character has been prepended to a string, the default metadata overrides it. Therefore it is necessary to use explicitly provided field data to override the default for strings whose base direction does not match the resource-wide default.</p>
+
 
 
 <div class="req" id="bp_default_fallback">

--- a/index.html
+++ b/index.html
@@ -165,7 +165,7 @@
 
 
 <section>
-<h3 id="resource_wide_defaults">Resource-wide defaults and string-specific metadata</h3>
+<h3 id="resource_wide_defaults">Provide metadata</h3>
 
 <div class="req" id="bp_lang_field_based_metadata">
 <p class="advisement">Use field-based metadata or string datatypes to indicate the language and the base direction for individual <a>localizable text</a> values.</p>


### PR DESCRIPTION
We need to start out by saying that we propose use of metadata, and whether or not a resource-wide option is available, there is always a need for string-specific metadata.  So it makes sense to move that requirement to the beginning of the section.  Then propose an optional resource-wide metadata declaration, in addition.  Then require that in the absence of metadata, language & direction are unknown, so that consumers can apply appropriate heuristics.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/string-meta/pull/70.html" title="Last updated on Jul 26, 2022, 4:15 PM UTC (e8008e7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/string-meta/70/905a6b2...e8008e7.html" title="Last updated on Jul 26, 2022, 4:15 PM UTC (e8008e7)">Diff</a>