### PR TITLE
Make decoration note consistent with other I18N specs

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,8 +19,8 @@
           edDraftURI:   		"https://w3c.github.io/string-meta/",
 
           editors:  [
-              { name: "Addison Phillips", mailto: "addison@amazon.com",
-                company: "Amazon.com", w3cid: 33573 },
+              { name: "Addison Phillips", mailto: "addisonI18N@gmail.com",
+                company: "Invited Expert", w3cid: 33573 },
               { name: "Richard Ishida", mailto: "ishida@w3.org",
                 company: "W3C", w3cid: 3439 },
 			     ],
@@ -142,8 +142,9 @@
 <p>In this section [[RFC2119]] keywords in uppercase italics have their usual meaning. We differentiate <em>best practices</em>, which should be adopted by all specifications and <em>recommendations</em>, which require additional standardization or which are speculative prior to adoption.</p>
 
 <div class="req" id="example_req">
-    <p class="advisement">Best practices appear with a different background color and decoration like this.</p>
-    <p class="gap">Gaps or recommendations for future work are listed as issues or displayed like this.</p>
+   <p class="advisement">Best practices appear with a different background color and decoration like this.</p>
+   <p class="definition">Definitions appear with a different background color and decoration like this.</p>
+   <p class="issue-example">Gaps or recommendations for future work appear with a different background color and decoration like this.</p>
 </div>
 </aside>
 
@@ -237,12 +238,12 @@
 <p class="advisement">Where the <code>i18n</code> Namespace is not available or is inappropriate to use, specifications SHOULD require [[JSON-LD]] plain string literals for natural language values to provide string-specific language information.</p>
 </div>
 
-<p>Some datatypes, such as [[RDF-PLAIN-LITERAL]], already exist that allow for <em>language</em> metadata to be serialized as part of a string value. Examples include:</p>
-<div class="example">
-<p>&quot;title&quot;: &quot;تصميم و إنشاء مواقع الويب@ar&quot;,</p>
-<p> &quot;tags&quot;: [ &quot;HTML@en&quot;, &quot;CSS@en&quot;, &quot;تصميم المواقع@ar&quot; ]</p>
-<p>&quot;id&quot;: &quot;978-111887164-5@und&quot;</p>
-</div>
+<p>Some datatypes, such as [[RDF-PLAIN-LITERAL]], already exist that allow for <em>language</em> metadata to be serialized as part of a string value.</p>
+<aside class="example" title="Examples of RDF plain literals">
+<pre>&quot;title&quot;: &quot;تصميم و إنشاء مواقع الويب@ar&quot;,
+&quot;tags&quot;: [ &quot;HTML@en&quot;, &quot;CSS@en&quot;, &quot;تصميم المواقع@ar&quot; ],
+&quot;id&quot;: &quot;978-111887164-5@und&quot;</pre>
+</aside>
 
 <div class="req" id="bp-do_not_use_language_non_data">
 	<p class="advisement">Specifications SHOULD NOT specify or require the use of language metadata for fields that cannot contain natural language text.</p>

--- a/index.html
+++ b/index.html
@@ -142,8 +142,9 @@
 <p>In this section [[RFC2119]] keywords in uppercase italics have their usual meaning. We differentiate <em>best practices</em>, which should be adopted by all specifications and <em>recommendations</em>, which require additional standardization or which are speculative prior to adoption.</p>
 
 <div class="req" id="example_req">
-    <p class="advisement">Best practices appear with a different background color and decoration like this.</p>
-    <!--p class="gap">Gaps or recommendations for future work are listed as issues or displayed like this.</p-->
+   <p class="advisement">Best practices appear with a different background color and decoration like this.</p>
+   <p class="definition">Definitions appear with a different background color and decoration like this.</p>
+   <p class="issue-example">Gaps or recommendations for future work appear with a different background color and decoration like this.</p>
 </div>
 </aside>
 

--- a/index.html
+++ b/index.html
@@ -50,9 +50,7 @@
 
 
 <div id="sotd">
-  <p>We welcome comments on this document, but to make it easier to track them, please raise 
-  separate issues for each comment, and point to the section 
-  you are commenting on using a URL.</p>
+  <p>We welcome comments on this document, but to make it easier to track them, please raise separate issues for each comment, and point to the section you are commenting on using a URL.</p>
 </div>
 
 <section>
@@ -65,6 +63,20 @@
 <p><a>Natural language</a> information on the Web depends on and benefits from the presence of language and direction metadata. Along with support for Unicode, mechanisms for including and specifying the base direction and the <a>natural language</a> of spans of text are one of the key internationalization considerations when developing new formats and technologies for the Web.</p>
 
 <p>Markup formats, such as HTML and XML, as well as related styling languages, such as CSS and XSL, are reasonably mature and provide support for the interchange and presentation of the world's languages via built-in features. Strings and string-based data formats need similar mechanisms in order to ensure complete and consistent support for the world's languages and cultures.</p>
+
+<section id="conventions">
+	<h3>Document Conventions</h3>
+	
+<p>In this document [[RFC2119]] keywords in uppercase italics have their usual meaning. We also use these stylistic conventions:</p>
+
+<p class="definition-example"><strong>Definitions</strong> appear with a different background color and decoration like this.</p>
+<p class="advisement"><strong>Best practices</strong> appear with a different background color and decoration like this.</p>
+
+   <!-- Remove comment when adding an 'issue'
+<p class="issue-example" id="issue-example"><strong>Recommendations</strong> for future work appear with a different background color and decoration like this.</p>
+   -->
+
+</section>
 
 <section id="terminology">
 <h3>Terminology</h3>
@@ -138,32 +150,7 @@
 <h2 id="bp_and-reco">Best Practices, Recommendations, and Gaps</h2>
 <p>This section consists of the Internationalization (I18N) Working Group's set of best practices for identifying language and base direction in data formats on the Web. In some cases, there are gaps in existing standards, where the recommendations of the I18N WG require additional standardization or there might be barriers to full adoption.</p>
 
-<aside class="note">
-<p>In this section [[RFC2119]] keywords in uppercase italics have their usual meaning. We differentiate <em>best practices</em>, which should be adopted by all specifications and <em>recommendations</em>, which require additional standardization or which are speculative prior to adoption.</p>
-
-<div class="req" id="example_req">
-   <p class="advisement">Best practices appear with a different background color and decoration like this.</p>
-   <p class="definition">Definitions appear with a different background color and decoration like this.</p>
-   <p class="issue-example">Gaps or recommendations for future work appear with a different background color and decoration like this.</p>
-</div>
-</aside>
-
 <p>The main issue is how to establish a common <a>serialization agreement</a> between producers and consumers of data values so that each knows how to encode, find, and interpret the language and base direction of each data field. The use of metadata for supplying both the language and base direction of natural language string fields ensures that the necessary information is present, can be supplied and extracted with the minimal amount of processing, and does not require producers or consumers to scan or alter the data.</p>
-<p>This document describes a number of approaches for identifying language and direction information for strings.  These include the following:</p>
-<ul>
-<li>fields that set a default language and direction for all strings in that resource</li>
-<li>string-specific fields or string datatypes to specify language and direction</li>
-<li>first-strong heuristics</li>
-<li>first-strong heuristics augmented by directional markers at the start of the string</li>
-<li>string-internal markup</li>
-<li>inference of direction from special applications of language data.</li>
-</ul>
-<p>The use of some of the above preclude the use of others, and in some cases some of the above approaches may need to be specified together to cater for fallback situations.</p>
-
-
-
-
-
 
 <section>
 <h3 id="resource_wide_defaults">Resource-wide &amp; string-specific defaults</h3>
@@ -270,9 +257,6 @@
 </section>
 
 
-
-
-
 <section>
 <h3 id="technology_specific_solutions">Technology-specific solutions</h3>
 
@@ -292,12 +276,14 @@
 <p class="advisement">Where the <code>i18n</code> Namespace is not available or is inappropriate to use, specifications SHOULD require [[JSON-LD]] plain string literals for natural language values to provide string-specific language information.</p>
 </div>
 
-<p>Some datatypes, such as [[RDF-PLAIN-LITERAL]], already exist that allow for <em>language</em> metadata to be serialized as part of a string value. Examples include:</p>
-<div class="example">
-<p>&quot;title&quot;: &quot;تصميم و إنشاء مواقع الويب@ar&quot;,</p>
-<p> &quot;tags&quot;: [ &quot;HTML@en&quot;, &quot;CSS@en&quot;, &quot;تصميم المواقع@ar&quot; ]</p>
-<p>&quot;id&quot;: &quot;978-111887164-5@und&quot;</p>
-</div>
+<p>Some datatypes, such as [[RDF-PLAIN-LITERAL]], already exist that allow for <em>language</em> metadata to be serialized as part of a string value.</p>
+<aside class="example" title="Examples of RDF plain literals with language tags">
+<pre>
+&quot;title&quot;: &quot;تصميم و إنشاء مواقع الويب@ar&quot;,
+&quot;tags&quot;: [ &quot;HTML@en&quot;, &quot;CSS@en&quot;, &quot;تصميم المواقع@ar&quot; ]
+&quot;id&quot;: &quot;978-111887164-5@und&quot;
+</pre>
+</aside>
 
 
 <div class="req" id="bp_localizable">

--- a/local.css
+++ b/local.css
@@ -131,6 +131,16 @@ a.self:hover {
     margin: 1em auto;
 }
 
+.issue-example {
+    position: relative;
+    background: #FBE9E9;
+    padding: 0.5em;
+    border: 0.5em;
+    border-left: 6pt solid #E05252;
+    border-right: 6pt solid #E05252;
+    margin: 1em auto;
+}
+
 .uname {
    font-size: 75%;
    letter-spacing: 0.05em;

--- a/local.css
+++ b/local.css
@@ -120,7 +120,24 @@ a.self:hover {
     margin: 1em auto;
 }
 
+.definition-example {
+    /* Used to style the example of a definition so that
+     * it doesn't participate in linking, etc.
+     */
+    position: relative;
+    background-color: #efefef;
+    padding: 0.5em;
+    border: 0.5em;
+    border-left: 6pt solid green;
+    border-right: 6pt solid green;
+    margin: 1em auto;
+}
+
 .issue-example {
+    /* Used to style the example of an issue so that
+     * it doesn't participate in linking, or auto-increment
+     * the counter
+     */
     position: relative;
     background: #FBE9E9;
     padding: 0.5em;

--- a/local.css
+++ b/local.css
@@ -63,17 +63,6 @@ p.cjk-demo {
     color: #63F;;
 }
 
-.gap {
-    background-color: #FCF;
-    font-style: italic;
-}
-
-.gap::before {
-    content: "\2757 \fe0f \00A0 ";
-    font-style: normal;
-    color: #63F;;
-}
-
 kbd {
    font-family: Menlo, Consolas, "DejaVu Sans Mono", Monaco, monospace;
    font-size: .95em;


### PR DESCRIPTION
I have been making all of our current WG Note documents use a consistent "example req" note. In a recent PR, @r12a commented out the `gap` style that is not currently used. In this PR I restore it using the correct style name (`issue`) and add the example of a terminology definition.

Note that we use the style `issue-example` (which I add to `local.css`) because `issue` has an auto-counter we don't want to trigger.

An argument can be made that we should omit the `issue` example until it is needed by this document. Thoughts?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/aphillips/string-meta/pull/71.html" title="Last updated on Jul 28, 2022, 3:46 PM UTC (01671f7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/string-meta/71/905a6b2...aphillips:01671f7.html" title="Last updated on Jul 28, 2022, 3:46 PM UTC (01671f7)">Diff</a>