### PR TITLE
Fix respec error

### DIFF
--- a/index.html
+++ b/index.html
@@ -1300,7 +1300,7 @@ members of the inheriting dictionary.</dd>
 dir</code></dfn> member</dt>
 <dd>Specifies the base direction for the human-readable members of an inheriting dictionary.</dd></dl>
 <div data-dfn-for="TextDirection" data-link-for="TextDirection" id="textdirection-enum" typeof="bibo:Chapter" resource="#textdirection-enum" property="bibo:hasPart">
-	<p id="h-textdirection-enum" resource="#h-textdirection-enum"><dfn data-dfn-for="" data-dfn-type="dfn" id="textdirection" data-idl="" data-title="TextDirection">
+	<p id="h-textdirection-enum" resource="#h-textdirection-enum"><dfn data-dfn-for="" data-dfn-type="dfn" id="textdirection" data-idl="" data-title="TextDirection" class="lint-ignore">
 <code>TextDirection</code></dfn> enum</p>
 <pre class="def idl">
 <span class="idlEnum" id="idl-def-textdirection" data-idl="" data-title="TextDirection">enum <span class="idlEnumID"><a data-lt="TextDirection" href="#textdirection" class="internalDFN" data-link-type="dfn" data-for=""><code>TextDirection</code></a></span> {    


### PR DESCRIPTION
Add `lint-ignore` to `TextDirection` enum `dfn` in the `Localizable` example definition.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/aphillips/string-meta/pull/72.html" title="Last updated on Aug 2, 2022, 5:32 PM UTC (709d782)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/string-meta/72/3b2c8f2...aphillips:709d782.html" title="Last updated on Aug 2, 2022, 5:32 PM UTC (709d782)">Diff</a>