### PR TITLE
page-break-inside was replaced by break-inside

### DIFF
--- a/local.css
+++ b/local.css
@@ -67,7 +67,7 @@ kbd {
    font-family: Menlo, Consolas, "DejaVu Sans Mono", Monaco, monospace;
    font-size: .95em;
    color: blue;
-   page-break-inside: avoid;
+   break-inside: avoid;
    hyphens: none;
    text-transform: none;
    text-align: left;


### PR DESCRIPTION
Ref: https://github.com/w3c/csswg-drafts/commit/36fa01c9bbef63780164134211a509717255169c