### PR TITLE
Implement the terms 'string direction' and 'block direction' in place of 'paragrah direction'

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,7 +98,7 @@
 
 <p class="definition"><dfn>Block direction</dfn>. The initial base direction of a block of text, which resolves to either <em>left-to-right</em> or <em>right-to-left</em>. A block refers to a unit of text as a whole, such as a paragraph in a document or a string in a data file. The name "block" is chosen as a contrast to <em>inline direction</em>. Unicode calls this value the [=paragraph direction=]. [[I18N-GLOSSARY]]</p>
 
-<p class="definition"><dfn>String direction</dfn>. The [=block direction=] specifically of a string. Strings transmitted inside various data structures are often inserted into a block (such as a paragraph). In such a case, the string direction is needed as part of the [=bidi isolation=] of the string.</p>
+<p class="definition"><dfn>String direction</dfn>. The overall direction of a specific string, which indicates the presentation order of string-internal directional runs. Strings transmitted inside various data structures are often inserted into a block (such as a paragraph). In such a case, the string direction is needed as part of the [=bidi isolation=] of the string.</p>
 
 <p>In this document we are concerned with identifying the <a>string direction</a> of a whole string and how to transmit and apply the string direction when displaying strings in various contexts. We do not talk about how to determine the direction or display of runs of text within a string.</p>
 
@@ -253,7 +253,7 @@
 	<section id="language-defaults">
 	<h4 id="resource_wide_default">Resource-wide Defaults</h4>
 			  
-	<p>When a document contains a number of natural language strings (and particularly if those string are all in the same language), using the localized string representation described above can become inefficient. To reduce the complexity of encoding these strings, specifications can establish a document-level default for language and [=block direction=]. These are separate values, as language does not imply direction. There should still be the ability to override either language or direction on any given string value by using the representation found <a href="#single-linguistic-field">above</a>.</p>
+	<p>When a document contains a number of natural language strings (and particularly if those string are all in the same language), using the localized string representation described above can become inefficient. To reduce the complexity of encoding these strings, specifications can establish a document-level default for language and [=string direction=]. These are separate values, as language does not imply direction. There should still be the ability to override either language or direction on any given string value by using the representation found <a href="#single-linguistic-field">above</a>.</p>
 			  
 	 <div class="req" id="bp_default_setting">
         <p class="advisement">Specifications MAY define a mechanism to provide the default language and the default [=string direction=] for all strings in a given resource. However, specifications MUST NOT assume that a resource-wide default is sufficient.  Even if a resource-wide setting is available, it must be possible to use string-specific metadata to override that default.</p>

--- a/index.html
+++ b/index.html
@@ -229,7 +229,7 @@
 
           <p>Use of heuristics to determine language or <a>paragraph direction</a> will always fail for certain cases, and there needs to be a way to provide the correct outcome for those strings. Assignment of <a href="#metadata">metadata</a> (either as a resource-wide default, or in a string-specific label) is an intentional act that removes the need to guess the outcome by applying heuristics.</p>
 
-          <p>The use of <a href="#metadata">metadata</a> for indicating base direction is  preferred because it avoids requiring the consumer to interpolate the direction using methods such as <a href="#firststrong">first strong</a> or use of methods which require modification of the data itself (such as the <a href="#rlm">insertion of RLM/LRM markers</a> or <a href="#paired">bidirectional controls</a>).</p>
+          <p>The use of <a href="#metadata">metadata</a> for indicating <a>paragraph direction</a> is preferred because it avoids requiring the consumer to interpolate the direction using methods such as <a href="#firststrong">first strong</a> or use of methods which require modification of the data itself (such as the <a href="#rlm">insertion of RLM/LRM markers</a> or <a href="#paired">bidirectional controls</a>).</p>
 
 <aside class="note">
     <p>Some schema languages, such as the RDF suite of specifications, have no built-in mechanism for associating base direction metadata with natural language string values. It is up to specifications that use these specifications to define structures and adopt best practices that result in clean interchange of language and direction metadata.</p>
@@ -279,7 +279,7 @@
 
     <p>Exceptions to the default are always a possibility, so it needs to be possible for users to override the default on a string-by-string basis.</p>
 
-    <p>First-strong heuristics are not applied to strings when the direction has been set externally using metadata. Even if a strongly directional character, such as <span class="codepoint" translate="no"><img alt="RLM" src="images/200F.png"><code class="uname">U+200F RIGHT-TO-LEFT MARK</code></span>, has been prepended to a string, resource-wide default metadata can override the presentation of the string in ways that result in <a>spillover</a> effects. Therefore content needs to be able to provide string-level metadata to override the default for strings whose base direction does not match the resource-wide default.</p>
+    <p>First-strong heuristics are not applied to strings when the direction has been set externally using metadata. Even if a strongly directional character, such as <span class="codepoint" translate="no"><img alt="RLM" src="images/200F.png"><code class="uname">U+200F RIGHT-TO-LEFT MARK</code></span>, has been prepended to a string, resource-wide default metadata can override the presentation of the string in ways that result in <a>spillover</a> effects. Therefore content needs to be able to provide string-level metadata to override the default for strings whose <a>paragraph direction</a> does not match the resource-wide default.</p>
 		  
 	<p>For specifications that can make use of the [[JSON-LD]] <code>@context</code> mechanism, use the <code>@language</code> and <code>@direction</code> fields to supply the document level defaults.</p>
               
@@ -349,7 +349,7 @@
 </div>
 
 <p>If metadata is not available, consumers of strings should use heuristics, preferably based on the Unicode Standard's first-strong detection algorithm, to detect the base direction of a string.</p>
-<p>The <a href="#firststrong">first-strong algorithm</a> looks for the first strongly-directional character in a string (skipping certain preliminary substrings), and assumes that it represents the base direction for the string as a whole. However, the first strong directional character doesn't always coincide with the required base direction for the string as a whole, so it should be possible to  provide metadata, where needed, to address this problem.</p>
+<p>The <a href="#firststrong">first-strong algorithm</a> looks for the first strongly-directional character in a string (skipping certain preliminary substrings), and assumes that it represents the <a>paragraph direction</a> of the string as a whole. However, the first strong directional character doesn't always coincide with the actual base direction of the string as a whole, so it should be possible to  provide metadata, where needed, to address this problem.</p>
 
 <div class="req" id="bp_using_rlm_lrm">
 <p class="advisement">If relying on first-strong heuristics, allow content developers to use RLM/LRM at the beginning of a string where it is necessary to force a particular base direction, but do not prepend one of these characters to existing strings.</p>
@@ -359,14 +359,14 @@
 <p class="advisement">Do not rely on the availability of RLM/LRM formatting characters in most cases.</p>
 </div>
 
-<p>If string data is being provided by users or content developers in web forms or other simple environments, users may not be able to enter these formatting characters.  In fact, most users will probably be unaware that such characters exist, or how to use them.  A web form can render their use unnecessary for immediate inspection if it sets the base direction for the input (which it should).</p>
+<p>If string data is being provided by users or content developers in web forms or other simple environments, users may not be able to enter these formatting characters.  In fact, most users will probably be unaware that such characters exist, or how to use them.  A web form can render their use unnecessary for immediate inspection if it sets the <a>paragraph direction</a> for the input (which it should).</p>
 
 
 <div class="req" id="bp_inferring_from_language">
-<p class="advisement">Specifications SHOULD NOT allow a base direction to be <a href="#script_subtag">interpolated from available language metadata</a> unless direction metadata is not available and cannot otherwise be provided.</p>
+<p class="advisement">Specifications SHOULD NOT allow a <a>paragraph direction</a> to be <a href="#script_subtag">interpolated from available language metadata</a> unless direction metadata is not available and cannot otherwise be provided.</p>
 </div>
 
-<p>Not all resources make use of the available metadata mechanisms. The script subtag of a language tag (or the "likely" script subtag based on [[BCP47]] and [[LDML]]) can sometimes be used to provide a base direction when other data is not available. Note that using language information is a "last resort" and specifications SHOULD NOT use it as the primary way of indicating direction: make the effort to provide for metadata.</p>
+<p>Not all resources make use of the available metadata mechanisms. The script subtag of a language tag (or the "likely" script subtag based on [[BCP47]] and [[LDML]]) can sometimes be used to infer a base direction when other data is not available. Using language information is a "last resort" and specifications SHOULD NOT use it as the primary way of indicating base direction: make the effort to provide for metadata.</p>
 
 
 <section id="technology_specific_solutions">
@@ -403,7 +403,7 @@
 <h3>Strings that are part of a legacy protocol or format</h3>
 
 <div class="req" id="bp_legacy_fmt_dir">
-   <p class="advisement">For strings that cannot specify direction due to legacy format reasons, specifications SHOULD specify that base direction depends on first-strong heuristics.</p>
+   <p class="advisement">For strings that cannot specify direction due to legacy format reasons, specifications SHOULD specify that the <a>paragraph direction</a> of each string depends on first-strong heuristics.</p>
 </div>
 
 <div class="req" id="bp_legacy_fmt_nonlang">
@@ -438,7 +438,7 @@
 <section>
 <h2 id="defining_bidi_keywords">Defining Bidirectional Keywords in Specifications</h2>
 
-<p>A specification for a document format or protocol that includes natural language text will need to define a data field or attribute to store the direction of that natural language content. These definitions need to be consistent across the Web in order to ensure interoperability, as <a>consumers</a> of one document format will need to map the base direction to fields in documents that they produce or control the base direction in text fields for display. This section describes how to provide such a definition along with the specific content to use.</p>
+<p>A specification for a document format or protocol that includes natural language text values will need to define a data field or attribute to store the <a>paragraph direction</a> for each natural language content value. These definitions need to be consistent across the Web in order to ensure interoperability, because <a>consumers</a> of one document format will need to map the <a>paragraph direction</a> for values they receive to fields that they produce or will need to control the base direction when displaying the content. This section describes how to provide such a definition along with the specific content to use.</p>
 
 <p>There are two common use cases for defining content direction: (i) defining a <a>directional metadata field</a> for storing and transmitting the <a>paragraph direction</a> as a field in a data structure or (ii) defining a <a>direction attribute</a> to associate a <a>paragraph direction</a> with a given piece of natural language content.</p>
 
@@ -488,7 +488,7 @@
 
 <p>The value <code class="kw" translate="no">auto</code> indicates that the user agent uses the <a href="https://html.spec.whatwg.org/multipage/dom.html#the-dir-attribute">algorithm</a> for <code class="kw" translate="no">auto</code> defined by [[HTML]] to determine the base paragraph direction. This heuristic looks for the first character with a strong directionality, in a manner analogous to the Paragraph Level determination in the bidirectional algorithm [[UAX9]].</p>
 
-<p>When <code class="kw" translate="no">auto</code> is applied to multiple fields or to a document as a whole, it means that the direction should be individually derived for each field (with string-specific metadata providing an override for cases that cannot be determined automatically). It can be useful for labelling a group of mixed direction strings, when the base direction of most strings can be reliably determined using the first-strong heuristics. Whenever possible, the actual base direction (<code class="kw" translate="no">ltr</code> or <code class="kw" translate="no">rtl</code>) of individual strings should be stored or exchanged instead of <code class="kw" translate="no">auto</code>. Omitting the <a>direction field</a> is preferable when the value is truly unknown.</p>
+<p>When <code class="kw" translate="no">auto</code> is applied to multiple fields or to a document as a whole, it means that the direction should be individually derived for each field (with string-specific metadata providing an override for cases that cannot be determined automatically). It can be useful for labelling a group of mixed direction strings, when the <a>paragraph direction</a> of most strings can be reliably determined using the first-strong heuristics. Whenever possible, the actual <a>paragraph direction</a> (<code class="kw" translate="no">ltr</code> or <code class="kw" translate="no">rtl</code>) of individual strings should be stored or exchanged instead of <code class="kw" translate="no">auto</code>. Omitting the <a>direction field</a> is preferable when the value is truly unknown.</p>
 
 </section>
 
@@ -648,7 +648,7 @@ might look something like:</p>
 
 <p>Each of the above is a data field in a database somewhere. There is even information about what language the book is in: (<samp>"language": "ar"</samp>).</p>
 
-<p>A well-internationalized catalog would include additional metadata to what is shown above. That is, for each of the fields containing <a>localizable text</a>, such as the <samp>title</samp> and <samp>authors</samp> fields, there should be language and base direction information stored as metadata. (There may be other values as well, such as pronunciation metadata for sorting East Asian language information.) These metadata values are used by consumers of the data to influence the processing and enable the display of the items in a variety of ways. As the JSON data structure 
+<p>A well-internationalized catalog would include additional metadata to what is shown above. That is, for each of the fields containing <a>localizable text</a>, such as the <samp>title</samp> and <samp>authors</samp> fields, there should be language and <a>paragraph direction</a> information stored as metadata. (There may be other values as well, such as pronunciation metadata for sorting East Asian language information.) These metadata values are used by consumers of the data to influence the processing and enable the display of the items in a variety of ways. As the JSON data structure 
 provides no place to store or exchange these values, it is more difficult to construct internationalized applications.</p>
 
 <p>One work-around might be to encode the values using a mix of HTML and Unicode bidi controls, so that a data value might look like one of the following:</p>
@@ -699,16 +699,16 @@ data in an interchange format is not a good idea. These include:</p>
 
 <section>
 <h3 id="what_consumers_do">What consumers need to do to support direction</h3>
-<p>Given the <a href="">use cases</a> for bidirectional text, it will be clear that a consumer cannot simply insert a string into a target location without some additional work or preparation taking place, first to establish the appropriate base direction for the string being inserted, and secondly to apply bidi isolation around the string.</p>
+<p>Given the <a href="">use cases</a> for bidirectional text, it will be clear that a consumer cannot simply insert a string into a target location without some additional work or preparation taking place, first to establish the appropriate <a>paragraph direction</a> for the string being inserted, and secondly to apply bidi isolation around the string.</p>
 <p>This requires the presence of markup or Unicode formatting controls around the string. If the string's base direction is opposite that into which it is being inserted, the markup or control codes need to tightly wrap the string. Strings that are inserted adjacent to each other all need to be individually wrapped in order to avoid the spillover issues we saw in the previous section.</p>
 <p>[[HTML5]] provides base direction controls and isolation for any inline element when the <code class="kw" translate="no">dir</code> attribute is used, or when the <code class="kw" translate="no">bdi</code> element is used. When inserting strings into plain text environments, isolating Unicode formatting characters need to be used. (Unfortunately, support for the isolating characters, which the Unicode Standard recommends as the default for plain text/non-markup applications, is still not universal.)</p>
-<p>The trick is to ensure that the direction information provided by the markup or control characters reflects the base direction of the string.</p>
+<p>The trick is to ensure that the direction information provided by the markup or control characters reflects the <a>paragraph direction</a> of the string.</p>
 </section>
 </section>
 
 <section>
 <h2 id="bidi-approaches">Approaches Considered for Identifying the Base Direction</h2>
-<p>The fundamental problem for bidirectional text values is how a <a>consumer</a> of a string will know what base direction should be used for that string when it is eventually displayed to a user. Note that some of these approaches for identifying or estimating the base direction have utility in specific applications and are in use in different specifications such as [[HTML5]]. The issue here is which are appropriate to adopt generally and specify for use as a best practice in document formats.</p>
+<p>The fundamental problem for bidirectional text values is how a <a>consumer</a> of a string will know what base direction to use for that string when it is eventually displayed to a user. Note that some of these approaches for identifying or estimating the base direction have utility in specific applications and are in use in different specifications such as [[HTML5]]. The issue here is which are appropriate to adopt generally and specify for use as a best practice in document formats.</p>
 
 <section id="firststrong">
   <h3>First-strong property detection</h3>
@@ -782,14 +782,14 @@ data in an interchange format is not a good idea. These include:</p>
 <p>Metadata indicating the default direction for all the strings in a resource could also be set using an appropriate field.</p>
 <section>
 <h4>How it works</h4>
-<p>A producer ascertains the  base direction of the string and adds that to a metadata field that accompanies the string when it is stored or transmitted.</p>
+<p>A producer ascertains the base direction of the string and adds that to a metadata field that accompanies the string when it is stored or transmitted.</p>
 <p>There are several approaches to using metadata:</p>
 <ol>
-<li>Label every string for base direction.</li>
-<li>Provide a document-level default for base direction and only include metadata for strings whose value is different. The value <code>auto</code> is used when the direction of a string is not known.</li>
+<li>Label every string with a <a>paragraph direction</a>.</li>
+<li>Provide a document-level default for <a>paragraph direction</a> and only include metadata for strings whose value is different. The value <code>auto</code> is used when the direction of a string is not known.</li>
 <li>Rely on the consumer to do <a href="#firststrong">first-strong detection</a>, and label only those strings which would produce the wrong result (that is, a right-to-left string that starts with left-to-right strong characters).</li>
 </ol>
-<p>If storing or transmitting a set of strings at a time, it helps to have a field for the resource as a whole that sets a global, default base direction which can be inherited by all strings in the resource. Note that in addition to a global field, you still need the possibility of attaching string-specific metadata fields in cases where a string's base direction is not that of the default. The base direction set on an individual string must override the default.</p>
+<p>If storing or transmitting a set of strings at a time, it helps to have a field for the resource as a whole that sets a global, default <a>paragraph direction</a> which can be inherited by all strings in the resource. Note that in addition to a global field, you still need the possibility of attaching string-specific metadata fields in cases where a string's <a>paragraph direction</a> is not the same as the default value. The base direction set on an individual string must always override the default.</p>
 <p>Consumers would need to understand how to read the metadata sent with a string, and would need to apply first-strong heuristics in the absence of metadata.</p>
 
 <p>The use of the <a href="#use-the-localizable-data-structure">Localizable</a> dictionary structure is RECOMMENDED for individual values in JSON-based document formats, as it combines both language and direction metadata and, if consistently adopted, makes interchange between different formats easier.</p>
@@ -835,7 +835,7 @@ data in an interchange format is not a good idea. These include:</p>
 <li>Rely on the consumer to do <a href="#firststrong">first-strong detection</a>, and add a marker to only those strings which would produce the wrong result (eg. a RTL string that starts with LTR strong characters).</li>
 <li>Assume a default of LTR (no marker), and apply only RLM markers.</li>
 </ol>
-<p>Consumers  apply first-strong heuristics to detect the base direction for the string. The RLM and LRM characters are strongly typed, directionally, and should therefore indicate the appropriate base direction.</p>
+<p>Consumers apply first-strong heuristics to detect the base direction for the string. The RLM and LRM characters are strongly typed, directionally, and should therefore indicate the appropriate base direction.</p>
 <p>As described in [[[#firststrong]]], this approach is not relevant if directional information is provided via metadata.</p>
 </section>
 
@@ -898,13 +898,13 @@ access, to the original context of the string. Many document formats are generat
 
 <section>
 <h4>How it works</h4>
-<p>A producer ascertains the  base direction of the string and adds a directional formatting character (one of <span class="unicode">U+2066 LEFT-TO-RIGHT ISOLATE</span> (LRI), <span class="unicode">U+2067 RIGHT-TO-LEFT ISOLATE</span> (RLI),<span class="unicode"> U+2068 FIRST STRONG ISOLATE</span> (FSI),<span class="unicode"> U+202A LEFT-TO-RIGHT EMBEDDING</span> (LRE), or <span class="unicode">U+202B RIGHT-TO-LEFT EMBEDDING</span> (RLE)) to the beginning of the string, and  <span class="unicode">U+2069 POP DIRECTIONAL ISOLATE</span> (PDI) or  <span class="unicode">U+202C POP DIRECTIONAL FORMATTING</span> (PDF) to the end.</p>
+<p>A producer ascertains the base direction of the string and adds a directional formatting character (one of <span class="unicode">U+2066 LEFT-TO-RIGHT ISOLATE</span> (LRI), <span class="unicode">U+2067 RIGHT-TO-LEFT ISOLATE</span> (RLI),<span class="unicode"> U+2068 FIRST STRONG ISOLATE</span> (FSI),<span class="unicode"> U+202A LEFT-TO-RIGHT EMBEDDING</span> (LRE), or <span class="unicode">U+202B RIGHT-TO-LEFT EMBEDDING</span> (RLE)) to the beginning of the string, and  <span class="unicode">U+2069 POP DIRECTIONAL ISOLATE</span> (PDI) or  <span class="unicode">U+202C POP DIRECTIONAL FORMATTING</span> (PDF) to the end.</p>
 <p>There are a number of possible approaches:</p>
 <ol>
 <li>Add the formatting codes to every string.</li>
 <li>Rely on the consumer to do <a href="#firststrong">first-strong detection</a>, and add a marker to only those strings which would produce the wrong result (eg. a RTL string that starts with LTR strong characters).</li>
 </ol>
-<p>Consumers  would theoretically just insert the string in the place it will be displayed, and rely on the formatting codes to apply the base direction. However, things are not quite so simple (see below).</p>
+<p>Consumers  would theoretically just insert the string in the place it will be displayed, and rely on the formatting codes to manage directionality. However, things are not quite so simple (see below).</p>
 <p>There are two types of paired formatting characters. The original set of controls provide the ability to add an additional level of bidirectional "embedding" to the Unicode bidirectional Algorithm. More recently, Unicode added a complementary set of "isolating" controls. Isolating controls are used to surround a string. The inside of the string is treated as its own bidirectional sequence, and the string is protected against spill-over effects related to any surrounding text. The enclosing string treats the entire surrounded string as a single unit that is ignored for bidi reordering. This issue is described <a href="https://www.w3.org/TR/html-bidi/#bidi-isolation-problem">here</a>.</p>
 <table>
 <tbody>
@@ -970,7 +970,7 @@ access, to the original context of the string. Many document formats are generat
 <p>A  producer and a consumer of a string would need to recognise and handle a situation where a string begins with a paired formatting character but doesn't end with it because the formatting characters only describe a part of the string.</p>
 <p>Unicode specifies a limit to the number of embeddings that are effective, and embeddings could build up over time to exceed that limit.</p>
 <p>Consuming applications would need to recognise and appropriately handle the isolating formatting characters. At the moment such support for RLI/LRI/FSI is far from pervasive.</p>
-<p>This approach would disqualify the string from being amenable to UBA first-strong heuristics if used by a non-aware consumer, because the Unicode bidi algorithm is unable to ascertain the base direction for a string that starts with RLI/LRI/FSI and ends with PDI. This is because the algorithm skips over isolated sequences and treats them  as a neutral character. A consumer of the string would have to take special steps, in this case, to uncover the first-strong character.</p>
+<p>This approach would disqualify the string from being amenable to UBA first-strong heuristics if used by a non-aware <a>consumer</a>, because the Unicode bidi algorithm is unable to ascertain the base direction for a string that starts with RLI/LRI/FSI and ends with PDI. This is because the algorithm skips over isolated sequences and treats them as a neutral character. A <a>consumer</a> of the string would have to take special steps in such a case to locate the first-strong character.</p>
 
 </section>
 </section>
@@ -997,7 +997,7 @@ access, to the original context of the string. Many document formats are generat
 
 <p>Language information MUST use [[BCP47]] language tags. The portion of the language tag that carries the information is the script subtag, not the primary language subtag. For example, Azeri may be written LTR (with the Latin or Cyrillic scripts) or RTL (with the Arabic script).  Therefore, the subtag <code class="kw" translate="no">az</code> is insufficient to clarify intended base direction. A language tag such as <code class="kw" translate="no">az-Arab</code> (Azeri as written in the Arabic script), however, can generally be relied upon to indicate that the overall base direction should be RTL. </p>
  
-<aside class=note>
+<aside class="note">
 	
 <p>Script subtags should only be used in language tags when the language's script is not implied by other information in the language tag. Implementations and specifications SHOULD NOT require the addition or generation of script subtags not already present in a language tag. The IANA Language Subtag Registry, defined by [[BCP47]] contains a <code class="kw">Suppress-Script</code> field for a few languages, indicating the script where it is missing. Additionally, the [[LDML]] specification defines a "likely subtag" mechanism that can often be used to supply a missing script subtag. For example, language tags such as <code class="kw">ar</code> (Arabic) or <code class="kw">ar-EG</code> (Arabic as used in Egypt), imply the <code class="kw">Arab</code> (Arabic) script subtag, since nearly all Arabic is written in this script.</p>
 
@@ -1020,7 +1020,7 @@ access, to the original context of the string. Many document formats are generat
 <section>
 <h4>Issues</h4>
 <p>The use of metadata as outlined above is a much better approach, if it is available. This script-related approach is only for use where that approach is unavailable, for legacy reasons.</p>
-<p>There are many strings which are not language-specific but which absolutely need to be  associated  with  a particular base direction for correct consumption. For example, MAC addresses inserted into a RTL context need to be displayed with a LTR overall base direction and isolation from the surrounding text. It's not clear how to distinguish these cases from others (in a way that would be feasible when using direction metadata). Special language tags, such as <code class="kw">zxx</code> (Non-Linguistic), exist for identifying this type of content, but usually data fields of this type omit language information altogether, since it is not applicable.</p>
+<p>There are many strings which are not language-specific but which absolutely need to be associated with a particular base direction for correct consumption. For example, MAC addresses inserted into a RTL context need to be displayed with a LTR overall base direction and isolation from the surrounding text. It's not clear how to distinguish these cases from others (in a way that would be feasible when using direction metadata). Special language tags, such as <code class="kw">zxx</code> (Non-Linguistic), exist for identifying this type of content, but usually data fields of this type omit language information altogether, since it is not applicable.</p>
 <p>The list of script subtags may be added to in future. In that case, any subtags that indicate a default RTL direction need to be added to the lists used by the consumers of the strings.</p>
 <p>There are some rare situations where the appropriate base direction cannot be identified from the script subtag, but these are really limited to archaic usage of text.  For example, Japanese and Chinese text prior to World War 2 was often written RTL, rather than LTR. Languages such as those written using Egyptian Hieroglyphs, or the Tifinagh Berber script, could formerly be written either LTR or RTL, however the default for scholastic research tends to LTR.</p>
 </section>
@@ -1029,7 +1029,7 @@ access, to the original context of the string. Many document formats are generat
 
 <section>
 <h4>Other comments</h4>
-<p>The approach outlined here is only appropriate when declaring information about the <em>overall</em> base direction to be associated with a string. We do <em>not</em> recommend  use of language data to indicate text direction within strings, since the usage patterns are not interchangeable.</p>
+<p>The approach outlined here is only appropriate when declaring information about the <em>overall</em> <a>paragraph direction</a> to be associated with a string. We do <em>not</em> recommend  use of language data to indicate text direction within strings, since the usage patterns are not interchangeable.</p>
 </section>
 </section>
 
@@ -1058,7 +1058,7 @@ access, to the original context of the string. Many document formats are generat
 <p>The benefit for content that already uses markup is clear. The content will already provide complete markup necessary for the display and processing of the text or it can be extracted from the source page context. HTML and XML processors already know how to deal with this markup and provide ready validation.</p>
 <p>For HTML, the <code class="kw" translate="no">dir</code> attribute bidirectionally isolates the content from the surrounding text, which removes spillover conflicts. This reduces the work of the consumer.</p>
 		
-		<p>Markup can also be used for string-internal directional information, something base direction on its own cannot solve.</p>
+		<p>Markup can also be used for string-internal directional information, something <a>paragraph direction</a> on its own cannot solve.</p>
     </section>
     <section>
 		<h4 id="html-content-issues">Issues</h4>
@@ -1082,7 +1082,7 @@ access, to the original context of the string. Many document formats are generat
     <section>
 	
 	<h4 id="dir-approach-new-datatype-how">How it works</h4>
-    <p>This is similar to the idea of sending metadata with a string as discussed previously, however the metadata is not stored in a completely separate field (as in  <a href="#metadata"></a>), or inserted into the string itself (as in <a href="#rlm"></a>), but is associated with the string as part of the string format itself.</p>
+    <p>This is similar to the idea of sending metadata with a string as discussed previously, however the metadata is not stored in a completely separate field (as in  <a href="#metadata"></a>), or inserted into the string itself (as in <a href="#rlm"></a>), but is associated with the string as part of the string's serialization format.</p>
     <p>Some datatypes, such as [[RDF-PLAIN-LITERAL]], already exist that allow for <em>language</em> metadata to be serialized as part of a string value. However, these do not include a consideration for base direction. This might be addressed by defining a new datatype (or extending an existing one) that document formats could then use to serialize natural language strings that includes both language and direction metadata.</p>
     <p>[[JSON-LD]] 1.1. added the <code class="kw" translate="no">i18n</code> Namespace to permit JSON documents to serialize language and direction metadata directly with a string value. It provides a deserialization to RDF for specifications that need it.</p>
   
@@ -1098,9 +1098,9 @@ myDataString:          "978-0-123-4567-X"^^i18n:_ltr          // language-neutra
 </aside>
 
 <p>Note that the last string does not include language information  because it is an internal data value, but <em>does</em> include direction information because strings of this kind <em>must</em> be presented in the LTR order.</p>
-<p>Producers would need to attach the direction information to a string.</p>
-<p>Again, it would be sensible to establish rules that expect the consumer to use <a href="#firststrong">first-strong heuristics</a> for those strings that are amenable to that approach, and for the producer to only add directional information if the first-strong approach would otherwise produce the wrong result. This would greatly simplify the management of strings and the amount of data to be transmittted, because the number of strings requiring metadata is relatively small.</p>
-<p>The consumer would look to see whether the string has metadata associated with it, in which case it would set the indicated base direction. Otherwise, it would use first-strong heuristics to determine the base direction of the string.</p>
+<p>A <a>producer</a> would need to attach the <a>paragraph direction</a> to each string as needed.</p>
+<p>Each <a>consumer</a> should use <a href="#firststrong">first-strong heuristics</a> for those strings that don't use this approach or do not contain <a>paragraph direction</a>. The <a>producer</a> would then only add <a>paragraph direction</a> information if the first-strong approach would otherwise produce the wrong result. This might simplify the management of strings and the amount of data to be transmittted, because the number of strings requiring metadata is relatively small.</p>
+<p>The <a>consumer</a> would look to see whether the string has metadata associated with it, in which case it would set the indicated base direction. Otherwise, it would use first-strong heuristics to determine the base direction of the string.</p>
 
   </section>
 <section>

--- a/index.html
+++ b/index.html
@@ -232,8 +232,8 @@
           <p>The use of <a href="#metadata">metadata</a> for indicating <a>paragraph direction</a> is preferred because it avoids requiring the consumer to interpolate the direction using methods such as <a href="#firststrong">first strong</a> or use of methods which require modification of the data itself (such as the <a href="#rlm">insertion of RLM/LRM markers</a> or <a href="#paired">bidirectional controls</a>).</p>
 
 <aside class="note">
-    <p>Some schema languages, such as the RDF suite of specifications, have no built-in mechanism for associating base direction metadata with natural language string values. It is up to specifications that use these specifications to define structures and adopt best practices that result in clean interchange of language and direction metadata.</p>
-    <p>For example, [[JSON-LD]] provides a document-level base direction using the <code class="kw" translate="no">@context</code> mechanism and defines the <code class="kw" translate="no">i18n</code> namespace as an extension of existing RDF datatypes which can be used to set the language and/or base direction of string values.</p>
+    <p>Some schema languages, such as the RDF suite of specifications, have no built-in mechanism for associating [=paragraph direction=] metadata with natural language string values. It is up to specifications that use these specifications to define structures and adopt best practices that result in clean interchange of language and direction metadata.</p>
+    <p>For example, [[JSON-LD]] provides a document-level [=paragraph direction=] using the <code class="kw" translate="no">@context</code> mechanism and defines the <code class="kw" translate="no">i18n</code> namespace as an extension of existing RDF datatypes which can be used to set the language, [=paragraph direction=], or both of string values.</p>
 </aside>
 
 
@@ -251,7 +251,7 @@
 	<p>When a document contains a number of natural language strings (and particularly if those string are all in the same language), using the localized string representation described above can become inefficient. To reduce the complexity of encoding these strings, specifications can establish a document-level default for language and base paragraph direction. These are separate values, as language does not imply direction. There should still be the ability to override either language or direction on any given string value by using the representation found <a href="#single-linguistic-field">above</a>.</p>
 			  
 	 <div class="req" id="bp_default_setting">
-        <p class="advisement">Specifications MAY define a mechanism to provide the default language and the default base direction for all strings in a given resource. However, specifications MUST NOT assume that a resource-wide default is sufficient.  Even if a resource-wide setting is available, it must be possible to use string-specific metadata to override that default.</p>
+        <p class="advisement">Specifications MAY define a mechanism to provide the default language and the default [=paragraph direction=] for all strings in a given resource. However, specifications MUST NOT assume that a resource-wide default is sufficient.  Even if a resource-wide setting is available, it must be possible to use string-specific metadata to override that default.</p>
      </div>
 
 	 <p>If your specification defines its own document level defaults, provide two optional fields:</p>
@@ -260,7 +260,7 @@
 		<p class="advisement">A document-level default language field SHOULD be called <code>language</code> and SHOULD be specified to contain a <a>valid</a> [[BCP47]] language tag. Specifications SHOULD specify that implementations are only require to check if a [[BCP47]] language tag is <a>well-formed</a>.</p>
 	 </div>
      <div class="req" id="bp-document-direction-default">
-		<p class="advisement">A document-level default <a>base direction</a> field SHOULD be called <code>direction</code> and support the values <code>ltr</code>, <code>rtl</code>, or <code>auto</code>.</p>
+		<p class="advisement">A document-level default <a>paragraph direction</a> field SHOULD be called <code>direction</code> and support the values <code>ltr</code>, <code>rtl</code>, or <code>auto</code>.</p>
 	</div>
 
     <aside class="example" title="Example of document level defaults">
@@ -345,11 +345,11 @@
 </section>
 
 <div class="req" id="bp_use_heuristics_1">
-<p class="advisement">For the case where the direction is not known, specify that consumers should use first-strong heuristics to identify the base direction of strings.</p>
+<p class="advisement">For the case where the paragraph direction is not known, specify that consumers should use first-strong heuristics to identify the [=paragraph direction=] of each string.</p>
 </div>
 
 <p>If metadata is not available, consumers of strings should use heuristics, preferably based on the Unicode Standard's first-strong detection algorithm, to detect the base direction of a string.</p>
-<p>The <a href="#firststrong">first-strong algorithm</a> looks for the first strongly-directional character in a string (skipping certain preliminary substrings), and assumes that it represents the <a>paragraph direction</a> of the string as a whole. However, the first strong directional character doesn't always coincide with the actual base direction of the string as a whole, so it should be possible to  provide metadata, where needed, to address this problem.</p>
+<p>The <a href="#firststrong">first-strong algorithm</a> looks for the first strongly-directional character in a string (skipping certain preliminary substrings), and assumes that it represents the <a>paragraph direction</a> of the string as a whole. However, the first strong directional character doesn't always coincide with the actual or desired [=paragraph direction=] of the string as a whole, so it should be possible to  provide metadata, where needed, to address this problem.</p>
 
 <div class="req" id="bp_using_rlm_lrm">
 <p class="advisement">If relying on first-strong heuristics, allow content developers to use RLM/LRM at the beginning of a string where it is necessary to force a particular base direction, but do not prepend one of these characters to existing strings.</p>
@@ -366,7 +366,7 @@
 <p class="advisement">Specifications SHOULD NOT allow a <a>paragraph direction</a> to be <a href="#script_subtag">interpolated from available language metadata</a> unless direction metadata is not available and cannot otherwise be provided.</p>
 </div>
 
-<p>Not all resources make use of the available metadata mechanisms. The script subtag of a language tag (or the "likely" script subtag based on [[BCP47]] and [[LDML]]) can sometimes be used to infer a base direction when other data is not available. Using language information is a "last resort" and specifications SHOULD NOT use it as the primary way of indicating base direction: make the effort to provide for metadata.</p>
+<p>Not all resources make use of the available metadata mechanisms. The script subtag of a language tag (or the "likely" script subtag based on [[BCP47]] and [[LDML]]) can sometimes be used to infer a [=paragraph direction=] when other data is not available. Using language information is a "last resort" and specifications SHOULD NOT use it as the primary way of indicating paragraph direction: make the effort to provide for metadata.</p>
 
 
 <section id="technology_specific_solutions">
@@ -377,7 +377,7 @@
 </div>
 
 
-<p>For document formats that use it, [[JSON-LD]] includes some data structures that are helpful in assigning language (but not base direction) metadata to collections of strings (including entire resources). Notably, it defines what it calls “string internationalization” in the form of a context-scoped <code class="kw" translate="no">@language</code> value which can be associated with blocks of JSON or within individual objects. There is no definition for base direction, so the <code class="kw" translate="no">@context</code> mechanism does not currently address all concerns raised by this document.</p>
+<p>For document formats that use it, [[JSON-LD]] includes some data structures that are helpful in assigning language (but not paragraph direction) metadata to collections of strings (including entire resources). Notably, it defines what it calls "string internationalization" in the form of a context-scoped <code class="kw" translate="no">@language</code> value which can be associated with blocks of JSON or within individual objects. There is no definition for base direction, so the <code class="kw" translate="no">@context</code> mechanism does not currently address all concerns raised by this document.</p>
 
 
 <div class="req" id="bp-use_jsonld_i18n_namespace">
@@ -438,14 +438,14 @@
 <section>
 <h2 id="defining_bidi_keywords">Defining Bidirectional Keywords in Specifications</h2>
 
-<p>A specification for a document format or protocol that includes natural language text values will need to define a data field or attribute to store the <a>paragraph direction</a> for each natural language content value. These definitions need to be consistent across the Web in order to ensure interoperability, because <a>consumers</a> of one document format will need to map the <a>paragraph direction</a> for values they receive to fields that they produce or will need to control the base direction when displaying the content. This section describes how to provide such a definition along with the specific content to use.</p>
+<p>A specification for a document format or protocol that includes natural language text values will need to define a data field or attribute to store the <a>paragraph direction</a> for each natural language content value. These definitions need to be consistent across the Web in order to ensure interoperability, because <a>consumers</a> of one document format will need to map the <a>paragraph direction</a> for values they receive to fields that they produce or will need to control the <a>paragraph direction</a> of each string when displaying the content. This section describes how to provide such a definition along with the specific content to use.</p>
 
 <p>There are two common use cases for defining content direction: (i) defining a <a>directional metadata field</a> for storing and transmitting the <a>paragraph direction</a> as a field in a data structure or (ii) defining a <a>direction attribute</a> to associate a <a>paragraph direction</a> with a given piece of natural language content.</p>
 
 <p class="definition"><dfn data-lt="directional metadata field|direction field">Directional metadata field</dfn>. A directional metadata field (or <strong>direction field</strong> for short) is a field in a data structure used to associate a paragraph direction with a given natural language string field or data value.</p>
 
 <aside class="example" id="example-direction-metadata">
-	<p><strong>Example of a <a>direction field</a>.</strong> In this JSON fragment, the <code>title</code> structure has a field <code>direction</code> which represents the <a>base direction</a> to use for the field <code>value</code>.</p>
+	<p><strong>Example of a <a>direction field</a>.</strong> In this JSON fragment, the <code>title</code> structure has a field <code>direction</code> which represents the <a>paragraph direction</a> to use for the field <code>value</code>.</p>
 <pre class="json">"title": {
 	"value": "HTML و CSS: تصميم و إنشاء مواقع الويب",
 	"direction": "rtl",
@@ -482,9 +482,9 @@
    <p class="advisement">Define the values of a <a>directional metadata field</a> or a <a>direction attribute</a> to include and be limited to the values <code class="kw" translate="no">ltr</code>, <code class="kw" translate="no">rtl</code>, and <code class="kw" translate="no">auto</code>.</p>
 </div>
 
-<p>The value <code class="kw" translate="no">ltr</code> indicates a base direction of left-to-right, in exactly the same manner indicated by <a href="https://www.w3.org/TR/css-writing-modes/#direction">CSS writing modes</a> [[CSS-WRITING-MODES-4]]</p>
+<p>The value <code class="kw" translate="no">ltr</code> indicates a direction of left-to-right, in exactly the same manner indicated by <a href="https://www.w3.org/TR/css-writing-modes/#direction">CSS writing modes</a> [[CSS-WRITING-MODES-4]]</p>
 
-<p>The value <code class="kw" translate="no">rtl</code> indicates a base direction of right-to-left, in exactly the same manner indicated by <a href="https://www.w3.org/TR/css-writing-modes/#direction">CSS writing modes</a> [[CSS-WRITING-MODES-4]]</p>
+<p>The value <code class="kw" translate="no">rtl</code> indicates a direction of right-to-left, in exactly the same manner indicated by <a href="https://www.w3.org/TR/css-writing-modes/#direction">CSS writing modes</a> [[CSS-WRITING-MODES-4]]</p>
 
 <p>The value <code class="kw" translate="no">auto</code> indicates that the user agent uses the <a href="https://html.spec.whatwg.org/multipage/dom.html#the-dir-attribute">algorithm</a> for <code class="kw" translate="no">auto</code> defined by [[HTML]] to determine the base paragraph direction. This heuristic looks for the first character with a strong directionality, in a manner analogous to the Paragraph Level determination in the bidirectional algorithm [[UAX9]].</p>
 
@@ -521,7 +521,7 @@
 
 
 <aside class="example">
-<p>Here is the record used in the <a href="#base_example">original example</a> with a record-level default language and base direction added. It also shows the use of a Localizable string to override the document-level defaults for the <code class="kw">author</code> field. Note that this "worked example" is not valid.</p>
+<p>Here is the record used in the <a href="#base_example">original example</a> with a record-level default language and default paragraph direction added. It also shows the use of a Localizable string to override the document-level defaults for the <code class="kw">author</code> field. Note that this "worked example" is not valid.</p>
 <pre>
 {
     "@context": { 
@@ -591,9 +591,9 @@
 <p>Similarly, direction metadata is important to the Web. When a string 
 contains text in a script that runs right-to-left (RTL), it must be 
 possible to eventually display that string correctly when it reaches an 
-end user. For that to happen, it is necessary to establish what <a>base 
+end user. For that to happen, it is necessary to establish what <a>paragraph 
 direction</a> needs to be applied to the string as a whole. The 
-appropriate base direction cannot always be deduced by simply looking 
+appropriate paragraph direction cannot always be deduced by simply looking 
 at the string; even where it is possible, the producer and consumer of 
 the string  need to use the same heuristics to interpret the 
 direction.</p>
@@ -700,15 +700,15 @@ data in an interchange format is not a good idea. These include:</p>
 <section>
 <h3 id="what_consumers_do">What consumers need to do to support direction</h3>
 <p>Given the <a href="">use cases</a> for bidirectional text, it will be clear that a consumer cannot simply insert a string into a target location without some additional work or preparation taking place, first to establish the appropriate <a>paragraph direction</a> for the string being inserted, and secondly to apply bidi isolation around the string.</p>
-<p>This requires the presence of markup or Unicode formatting controls around the string. If the string's base direction is opposite that into which it is being inserted, the markup or control codes need to tightly wrap the string. Strings that are inserted adjacent to each other all need to be individually wrapped in order to avoid the spillover issues we saw in the previous section.</p>
+<p>This requires the presence of markup or Unicode formatting controls around the string. If the string's [=paragraph direction=] is opposite that of the content into which it is being inserted, the markup or control codes need to tightly wrap the string. Strings that are inserted adjacent to each other all need to be individually wrapped in order to avoid the spillover issues we saw in the previous section.</p>
 <p>[[HTML5]] provides base direction controls and isolation for any inline element when the <code class="kw" translate="no">dir</code> attribute is used, or when the <code class="kw" translate="no">bdi</code> element is used. When inserting strings into plain text environments, isolating Unicode formatting characters need to be used. (Unfortunately, support for the isolating characters, which the Unicode Standard recommends as the default for plain text/non-markup applications, is still not universal.)</p>
 <p>The trick is to ensure that the direction information provided by the markup or control characters reflects the <a>paragraph direction</a> of the string.</p>
 </section>
 </section>
 
 <section>
-<h2 id="bidi-approaches">Approaches Considered for Identifying the Base Direction</h2>
-<p>The fundamental problem for bidirectional text values is how a <a>consumer</a> of a string will know what base direction to use for that string when it is eventually displayed to a user. Note that some of these approaches for identifying or estimating the base direction have utility in specific applications and are in use in different specifications such as [[HTML5]]. The issue here is which are appropriate to adopt generally and specify for use as a best practice in document formats.</p>
+<h2 id="bidi-approaches">Approaches Considered for Identifying the Paragraph Direction</h2>
+<p>The fundamental problem for bidirectional text values is how a <a>consumer</a> of a string will know what [=paragraph direction=] to use for that string when it is eventually displayed to a user. Note that some of these approaches for identifying or estimating the paragraph direction have utility in specific applications and are in use in different specifications such as [[HTML5]]. The issue here is which are appropriate to adopt generally and specify for use as a best practice in document formats.</p>
 
 <section id="firststrong">
   <h3>First-strong property detection</h3>
@@ -717,13 +717,13 @@ data in an interchange format is not a good idea. These include:</p>
 <h4>How it works</h4>
 <p>A producer doesn't need to do anything.</p>
 <p>The string is stored as it is.</p>
-<p>Consumers must look for the first character in the string with a strong Unicode directional property, and set the base direction to match it. They then take appropriate action  to ensure that the string will be displayed as needed. This is not quite so simple as it may appear, for the following reasons:</p>
+<p>Consumers must look for the first character in the string with a strong Unicode directional property, and set the paragraph direction to match it. They then take appropriate action  to ensure that the string will be displayed as needed. This is not quite so simple as it may appear, for the following reasons:</p>
 <ol>
 <li>Characters at the start of a string without a strong direction (eg. punctuation, numbers, etc) and isolated sequences (ie. sequences of characters surrounded by RLI/LRI/FSI...PDI formatting characters) within a string must be skipped in order to find the first strong character.</li>
 <li>The detection algorithm needs to be able to handle markup at the start of the string. It needs to be able to tell whether the markup is just string text, or whether the markup needs to be parsed in the target location – in which case it must understand the markup, and understand any direction-related information that is carried in the markup.</li>
 </ol>
-<p>First-strong detection is only needed where the required base direction is not already known. If direction is indicated for a string by metadata, either string-specific or via a resource-wide declaration, then first-strong heuristics should not be invoked. For example, first-strong heuristics would produce the wrong result for a string such as &quot;<span lang="ar" dir="rtl">HTML و CSS: تصميم و إنشاء مواقع الويب</span>&quot;. This can be corrected using metadata, the use of which signifies informed intention, and you would not need or want to apply heuristics that would then make the result incorrect.</p>
-<p>However, if there is no mechanism for the application of metadata, or if there is such a mechanism but the content developer omitted to use it, then first-strong heuristics can be helpful to establish base direction in many, though not all, cases. The application of strongly-directional formatting characters can help produce correct results for plain text strings such as the example just quoted, but it is not always possible to apply those (see [[[#rlm]]]).</p>
+<p>First-strong detection is only needed where the required [=paragraph direction=] is not already known. If direction is indicated for a string by metadata, either string-specific or via a resource-wide declaration, then first-strong heuristics should not be invoked. For example, first-strong heuristics would produce the wrong result for a string such as &quot;<span lang="ar" dir="rtl">HTML و CSS: تصميم و إنشاء مواقع الويب</span>&quot;. This can be corrected using metadata, the use of which signifies informed intention, and you would not need or want to apply heuristics that would then make the result incorrect.</p>
+<p>However, if there is no mechanism for the application of metadata, or if there is such a mechanism but the content developer omitted to use it, then first-strong heuristics can be helpful to establish <a>base direction</a> in many, though not all, cases. The application of strongly-directional formatting characters can help produce correct results for plain text strings such as the example just quoted, but it is not always possible to apply those (see [[[#rlm]]]).</p>
 </section>
 
 <section>
@@ -757,7 +757,7 @@ data in an interchange format is not a good idea. These include:</p>
 <section>
 <h4>Additional notes</h4>
 
-<p>Although first-strong detection is outlined in the Unicode Bidirectional Algorithm (UBA) [[UAX9]], it is not the only possible higher-level protocol mentioned for estimating string direction. For example, Twitter and Facebook currently use different default heuristics for guessing the base direction of text – neither use just simple first-strong detection, and one uses a completely different method.</p>
+<p>Although first-strong detection is outlined in the Unicode Bidirectional Algorithm (UBA) [[UAX9]], it is not the only possible higher-level protocol mentioned for estimating string direction. For example, X (formerly known as Twitter) and Facebook currently use different default heuristics for guessing the base direction of text &mdash; neither use just simple first-strong detection, and one uses a completely different method.</p>
 </section>
 </section>
 
@@ -782,19 +782,19 @@ data in an interchange format is not a good idea. These include:</p>
 <p>Metadata indicating the default direction for all the strings in a resource could also be set using an appropriate field.</p>
 <section>
 <h4>How it works</h4>
-<p>A producer ascertains the base direction of the string and adds that to a metadata field that accompanies the string when it is stored or transmitted.</p>
+<p>A producer ascertains the [=paragraph direction=] of the string and adds that to a metadata field that accompanies the string when it is stored or transmitted.</p>
 <p>There are several approaches to using metadata:</p>
 <ol>
 <li>Label every string with a <a>paragraph direction</a>.</li>
 <li>Provide a document-level default for <a>paragraph direction</a> and only include metadata for strings whose value is different. The value <code>auto</code> is used when the direction of a string is not known.</li>
 <li>Rely on the consumer to do <a href="#firststrong">first-strong detection</a>, and label only those strings which would produce the wrong result (that is, a right-to-left string that starts with left-to-right strong characters).</li>
 </ol>
-<p>If storing or transmitting a set of strings at a time, it helps to have a field for the resource as a whole that sets a global, default <a>paragraph direction</a> which can be inherited by all strings in the resource. Note that in addition to a global field, you still need the possibility of attaching string-specific metadata fields in cases where a string's <a>paragraph direction</a> is not the same as the default value. The base direction set on an individual string must always override the default.</p>
+<p>If storing or transmitting a set of strings at a time, it helps to have a field for the resource as a whole that sets a global, default <a>paragraph direction</a> which can be inherited by all strings in the resource. Note that in addition to a global field, you still need the possibility of attaching string-specific metadata fields in cases where a string's <a>paragraph direction</a> is not the same as the default value. The [=paragraph direction=] set on an individual string must always override the default.</p>
 <p>Consumers would need to understand how to read the metadata sent with a string, and would need to apply first-strong heuristics in the absence of metadata.</p>
 
 <p>The use of the <a href="#use-the-localizable-data-structure">Localizable</a> dictionary structure is RECOMMENDED for individual values in JSON-based document formats, as it combines both language and direction metadata and, if consistently adopted, makes interchange between different formats easier.</p>
 		
-<p class=note>As noted <a href="#localizable-dictionary">here</a>, [[JSON-LD]] includes some data structures that are helpful in assigning language (but not base direction) metadata to collections of strings (including entire resources). These gaps in support for pre-built metadata at the resource or item level are one of the key reasons for this documents development.</p>
+<p class=note>As noted <a href="#localizable-dictionary">here</a>, [[JSON-LD]] includes some data structures that are helpful in assigning language (but not direction) metadata to collections of strings (including entire resources). These gaps in support for pre-built metadata at the resource or item level are one of the key reasons for this documents development.</p>
 </section>
 
 
@@ -802,8 +802,8 @@ data in an interchange format is not a good idea. These include:</p>
 <section>
 <h4>Advantages</h4>
 
-<p>Passing metadata as separate data value from the string provides a simple, effective and efficient method of communicating the intended base direction without affecting the actual content of the string.</p>
-<p>If every string is labelled for direction, or the direction for all strings can be ascertained by applying the global setting and any string-specific deviations, it avoids the need to inspect and run heuristics on the string to determine its base direction.</p>
+<p>Passing metadata as separate data value from the string provides a simple, effective and efficient method of communicating the intended [=paragraph direction=] without affecting the actual content of the string.</p>
+<p>If every string is labelled for direction, or the direction for all strings can be ascertained by applying the global setting and any string-specific deviations, it avoids the need to inspect and run heuristics to determine each separate string's [=paragraph direction=].</p>
 </section>
 
 
@@ -828,14 +828,14 @@ data in an interchange format is not a good idea. These include:</p>
 
 <section>
 <h4>How it works</h4>
-<p>A producer ascertains the  base direction of the string and adds an marker character (either <span class="unicode">U+200F RIGHT-TO-LEFT MARK</span> (RLM) or <span class="unicode">U+200E LEFT-TO-RIGHT MARK</span> (LRM)) to the beginning of the string. The marker is not functional, ie. it will not automatically apply a base direction to the string that can be used by the consumer, it is simply a marker.</p>
+<p>A producer ascertains the  [=paragraph direction=] of the string and adds an marker character (either <span class="unicode">U+200F RIGHT-TO-LEFT MARK</span> (RLM) or <span class="unicode">U+200E LEFT-TO-RIGHT MARK</span> (LRM)) to the beginning of the string. The marker is not functional, ie. it will not automatically apply a base direction to the string that can be used by the consumer, it is simply a marker.</p>
 <p>There are a number of possible approaches:</p>
 <ol>
 <li>Add a marker to every string (not recommended).</li>
 <li>Rely on the consumer to do <a href="#firststrong">first-strong detection</a>, and add a marker to only those strings which would produce the wrong result (eg. a RTL string that starts with LTR strong characters).</li>
 <li>Assume a default of LTR (no marker), and apply only RLM markers.</li>
 </ol>
-<p>Consumers apply first-strong heuristics to detect the base direction for the string. The RLM and LRM characters are strongly typed, directionally, and should therefore indicate the appropriate base direction.</p>
+<p>Consumers apply first-strong heuristics to detect the paragraph direction for the string. The RLM and LRM characters are strongly typed directionally, and should therefore result in detecting the appropriate base direction.</p>
 <p>As described in [[[#firststrong]]], this approach is not relevant if directional information is provided via metadata.</p>
 </section>
 
@@ -859,13 +859,7 @@ data in an interchange format is not a good idea. These include:</p>
 <p>A significant  problem with this, especially on mobile devices, is the 
   availability or inconvenience of inputting an RLM/LRM character. The keyboards of mobile devices generally do not provide keys for RLM/LRM characters. Perhaps more important, because the characters are invisible and because Unicode 
   bidi is complicated, it can be difficult for the user to know how to use the character effectively. In fact, a large percentage of users don't actually know what these characters are or what they do.</p>
-<p>Furthermore, if a person types information into, say, an HTML form in a RTL page or uses shortcut keys to set the direction for the form field, strings will look correct without the need to add 
-  RLM/LRM. However, 
-  used outside of that context the string would look incorrect unless it is associated with information about the required base direction. Similarly, strings 
-  scraped from a web page that has <code class="kw" 
-  translate="no">dir=rtl</code> set in the <code class="kw" 
-  translate="no">html</code> element would not normally have or need an 
-RLM/LRM character at the start of the string in HTML.</p>
+<p>Furthermore, if a person types information into, say, an HTML form in a RTL page or uses shortcut keys to set the direction for the form field, the strings will look correct without the need to add RLM/LRM. However, used outside of that context the string would look incorrect unless it is associated with information about the required [=paragraph direction=]. Similarly, strings scraped from a web page that has <code class="kw" translate="no">dir=rtl</code> set in the <code class="kw" translate="no">html</code> element would not normally have or need an RLM/LRM character at the start of the string in HTML.</p>
 <p>It may be possible for the steps used by a producer  to include an examination of the original context of the string for directional information (for example, by testing the computed direction of an HTML form field), followed by automatic insertion of an RLM/LRM mark into the beginning of the string where necessary. An issue with this approach is that it changes the string value and identity. This may also create problems for working with string length 
 or pointer positions, especially if some producers add markers and others don't.</p>
 <p>If directional information is contained in markup that will be 
@@ -898,7 +892,7 @@ access, to the original context of the string. Many document formats are generat
 
 <section>
 <h4>How it works</h4>
-<p>A producer ascertains the base direction of the string and adds a directional formatting character (one of <span class="unicode">U+2066 LEFT-TO-RIGHT ISOLATE</span> (LRI), <span class="unicode">U+2067 RIGHT-TO-LEFT ISOLATE</span> (RLI),<span class="unicode"> U+2068 FIRST STRONG ISOLATE</span> (FSI),<span class="unicode"> U+202A LEFT-TO-RIGHT EMBEDDING</span> (LRE), or <span class="unicode">U+202B RIGHT-TO-LEFT EMBEDDING</span> (RLE)) to the beginning of the string, and  <span class="unicode">U+2069 POP DIRECTIONAL ISOLATE</span> (PDI) or  <span class="unicode">U+202C POP DIRECTIONAL FORMATTING</span> (PDF) to the end.</p>
+<p>A producer ascertains the [=paragraph direction=] of the string and adds a directional formatting character (one of <span class="unicode">U+2066 LEFT-TO-RIGHT ISOLATE</span> (LRI), <span class="unicode">U+2067 RIGHT-TO-LEFT ISOLATE</span> (RLI),<span class="unicode"> U+2068 FIRST STRONG ISOLATE</span> (FSI),<span class="unicode"> U+202A LEFT-TO-RIGHT EMBEDDING</span> (LRE), or <span class="unicode">U+202B RIGHT-TO-LEFT EMBEDDING</span> (RLE)) to the beginning of the string, and  <span class="unicode">U+2069 POP DIRECTIONAL ISOLATE</span> (PDI) or  <span class="unicode">U+202C POP DIRECTIONAL FORMATTING</span> (PDF) to the end.</p>
 <p>There are a number of possible approaches:</p>
 <ol>
 <li>Add the formatting codes to every string.</li>
@@ -990,12 +984,12 @@ access, to the original context of the string. Many document formats are generat
 <ol>
 <li>Label every string for language, including a script subtag as needed. <a>Consumers</a> may need to compute the script subtag when the <a>producer</a> does not provide one.</li>
 <li>It might be reasonable to assume a default of LTR for all strings unless marked with a language tag whose script subtag (either present or implied) indicates RTL.</li>
-<li>Alternatively, limit the use of script subtag metadata to situations where <a href="#firststrong">first-strong heuristics</a> are expected to fail &mdash; provided that such cases can be identified, and appropriate action taken by the producer (not always reliable). <a>Consumers</a> would then need to use first-strong heuristics in the absence of a script subtag in order to identify the appropriate base direction. The use of script subtags should not, however, be restricted to strings that need to indicate direction; it is perfectly valid to associate a script subtag with any string.</li>
+<li>Alternatively, limit the use of script subtag metadata to situations where <a href="#firststrong">first-strong heuristics</a> are expected to fail &mdash; provided that such cases can be identified, and appropriate action taken by the producer (not always reliable). <a>Consumers</a> would then need to use first-strong heuristics in the absence of a script subtag in order to identify the appropriate [=paragraph direction=]. The use of script subtags should not, however, be restricted to strings that need to indicate direction; it is perfectly valid to associate a script subtag with any string.</li>
 <li>Set a default language for a set of strings at a higher level, but provide a mechanism to override that default for a given string where needed.</li>
 </ol>
-<p><a>Consumers</a> extract the script subtag from the language tag associated with each string, computing the string's base direction as necessary. Script subtags associated with RTL scripts are used to assign a base direction of RTL to their associated strings.</p>
+<p><a>Consumers</a> extract the script subtag from the language tag associated with each string, computing the string's [=paragraph direction=] as necessary. Script subtags associated with RTL scripts are used to assign a direction of RTL to their associated strings.</p>
 
-<p>Language information MUST use [[BCP47]] language tags. The portion of the language tag that carries the information is the script subtag, not the primary language subtag. For example, Azeri may be written LTR (with the Latin or Cyrillic scripts) or RTL (with the Arabic script).  Therefore, the subtag <code class="kw" translate="no">az</code> is insufficient to clarify intended base direction. A language tag such as <code class="kw" translate="no">az-Arab</code> (Azeri as written in the Arabic script), however, can generally be relied upon to indicate that the overall base direction should be RTL. </p>
+<p>Language information MUST use [[BCP47]] language tags. The portion of the language tag that carries the information is the script subtag, not the primary language subtag. For example, Azeri may be written LTR (with the Latin or Cyrillic scripts) or RTL (with the Arabic script).  Thus, the subtag <code class="kw" translate="no">az</code> is insufficient to clarify intended [=paragraph direction=]. A language tag such as <code class="kw" translate="no">az-Arab</code> (Azeri as written in the Arabic script), however, can generally be relied upon to indicate that the [=paragraph direction=] should be RTL. </p>
  
 <aside class="note">
 	
@@ -1011,8 +1005,8 @@ access, to the original context of the string. Many document formats are generat
 <h4>Advantages</h4>
 
 <p>There is no need to inspect or change the string itself.</p>
-<p>This approach avoids the issues associated with first-strong detection when the first-strong character is not indicative of the necessary base direction for the string, and avoids issues relating to the interpretation of markup.</p>
-<p>Note that a string that begins with markup that sets a language for the string text content (eg. <code translate="no">&lt;cite lang="zh-Hans"&gt;</code>) is not problematic here, since that language declaration is not expected to play into the setting of the base direction.</p>
+<p>This approach avoids the issues associated with first-strong detection when the first-strong character is not indicative of the necessary [=paragraph direction=] for the string, and avoids issues relating to the interpretation of markup.</p>
+<p>Note that a string that begins with markup that sets a language for the string text content (eg. <code translate="no">&lt;cite lang="zh-Hans"&gt;</code>) is not problematic here, since that language declaration is not expected to play into the setting of the [=paragraph direction=].</p>
 </section>
 
 
@@ -1020,9 +1014,9 @@ access, to the original context of the string. Many document formats are generat
 <section>
 <h4>Issues</h4>
 <p>The use of metadata as outlined above is a much better approach, if it is available. This script-related approach is only for use where that approach is unavailable, for legacy reasons.</p>
-<p>There are many strings which are not language-specific but which absolutely need to be associated with a particular base direction for correct consumption. For example, MAC addresses inserted into a RTL context need to be displayed with a LTR overall base direction and isolation from the surrounding text. It's not clear how to distinguish these cases from others (in a way that would be feasible when using direction metadata). Special language tags, such as <code class="kw">zxx</code> (Non-Linguistic), exist for identifying this type of content, but usually data fields of this type omit language information altogether, since it is not applicable.</p>
+<p>There are many strings which are not language-specific but which absolutely need to be associated with a particular [=paragraph direction=] for correct consumption. For example, MAC addresses inserted into a RTL context need to be displayed with a LTR overall base direction and also be isolated from the surrounding text. It's not clear how to distinguish these cases from others (in a way that would be feasible when using direction metadata). Special language tags, such as <code class="kw">zxx</code> (Non-Linguistic), exist for identifying this type of content, but usually data fields of this type omit language information altogether, since it is not applicable.</p>
 <p>The list of script subtags may be added to in future. In that case, any subtags that indicate a default RTL direction need to be added to the lists used by the consumers of the strings.</p>
-<p>There are some rare situations where the appropriate base direction cannot be identified from the script subtag, but these are really limited to archaic usage of text.  For example, Japanese and Chinese text prior to World War 2 was often written RTL, rather than LTR. Languages such as those written using Egyptian Hieroglyphs, or the Tifinagh Berber script, could formerly be written either LTR or RTL, however the default for scholastic research tends to LTR.</p>
+<p>There are some rare situations where the appropriate [=paragraph direction=] cannot be identified from the script subtag, but these are really limited to archaic usage of text.  For example, Japanese and Chinese text prior to World War 2 was often written RTL, rather than LTR. Languages such as those written using Egyptian Hieroglyphs, or the Tifinagh Berber script, could formerly be written either LTR or RTL, however the default for scholastic research tends to LTR.</p>
 </section>
 
 
@@ -1083,7 +1077,7 @@ access, to the original context of the string. Many document formats are generat
 	
 	<h4 id="dir-approach-new-datatype-how">How it works</h4>
     <p>This is similar to the idea of sending metadata with a string as discussed previously, however the metadata is not stored in a completely separate field (as in  <a href="#metadata"></a>), or inserted into the string itself (as in <a href="#rlm"></a>), but is associated with the string as part of the string's serialization format.</p>
-    <p>Some datatypes, such as [[RDF-PLAIN-LITERAL]], already exist that allow for <em>language</em> metadata to be serialized as part of a string value. However, these do not include a consideration for base direction. This might be addressed by defining a new datatype (or extending an existing one) that document formats could then use to serialize natural language strings that includes both language and direction metadata.</p>
+    <p>Some datatypes, such as [[RDF-PLAIN-LITERAL]], already exist that allow for <em>language</em> metadata to be serialized as part of a string value. However, these do not include a consideration for direction. This might be addressed by defining a new datatype (or extending an existing one) that document formats could then use to serialize natural language strings that includes both language and direction metadata.</p>
     <p>[[JSON-LD]] 1.1. added the <code class="kw" translate="no">i18n</code> Namespace to permit JSON documents to serialize language and direction metadata directly with a string value. It provides a deserialization to RDF for specifications that need it.</p>
   
 <aside class="example">  
@@ -1100,7 +1094,7 @@ myDataString:          "978-0-123-4567-X"^^i18n:_ltr          // language-neutra
 <p>Note that the last string does not include language information  because it is an internal data value, but <em>does</em> include direction information because strings of this kind <em>must</em> be presented in the LTR order.</p>
 <p>A <a>producer</a> would need to attach the <a>paragraph direction</a> to each string as needed.</p>
 <p>Each <a>consumer</a> should use <a href="#firststrong">first-strong heuristics</a> for those strings that don't use this approach or do not contain <a>paragraph direction</a>. The <a>producer</a> would then only add <a>paragraph direction</a> information if the first-strong approach would otherwise produce the wrong result. This might simplify the management of strings and the amount of data to be transmittted, because the number of strings requiring metadata is relatively small.</p>
-<p>The <a>consumer</a> would look to see whether the string has metadata associated with it, in which case it would set the indicated base direction. Otherwise, it would use first-strong heuristics to determine the base direction of the string.</p>
+<p>The <a>consumer</a> would look to see whether the string has metadata associated with it, in which case it would set the indicated [=paragraph direction=]. Otherwise, it would use first-strong heuristics to determine the paragraph direction of the string.</p>
 
   </section>
 <section>
@@ -1427,7 +1421,7 @@ myDataString:          "978-0-123-4567-X"^^i18n:_ltr          // language-neutra
 members of the inheriting dictionary.</dd>
 <dt><dfn data-dfn-for="localizable" data-dfn-type="dfn" id="localizable-dir" data-idl="" data-title="dir" class="lint-ignore"><code>
 dir</code></dfn> member</dt>
-<dd>Specifies the base direction for the human-readable members of an inheriting dictionary.</dd></dl>
+<dd>Specifies the [=paragraph direction=] for the human-readable members of an inheriting dictionary.</dd></dl>
 <div data-dfn-for="TextDirection" data-link-for="TextDirection" id="textdirection-enum" typeof="bibo:Chapter" resource="#textdirection-enum" property="bibo:hasPart">
 	<p id="h-textdirection-enum" resource="#h-textdirection-enum"><dfn data-dfn-for="" data-dfn-type="dfn" id="textdirection" data-idl="" data-title="TextDirection" class="lint-ignore">
 <code>TextDirection</code></dfn> enum</p>

--- a/index.html
+++ b/index.html
@@ -253,7 +253,7 @@
 	<section id="language-defaults">
 	<h4 id="resource_wide_default">Resource-wide Defaults</h4>
 			  
-	<p>When a document contains a number of natural language strings (and particularly if those string are all in the same language), using the localized string representation described above can become inefficient. To reduce the complexity of encoding these strings, specifications can establish a document-level default for language and [=string direction=]. These are separate values, as language does not imply direction. There should still be the ability to override either language or direction on any given string value by using the representation found <a href="#single-linguistic-field">above</a>.</p>
+	<p>When a resource contains a number of natural language strings (and particularly if those string are all in the same language), using the localized string representation described above can become inefficient. To reduce the complexity of encoding these strings, specifications can establish a resource-level default for language and [=string direction=]. These are separate values, as language does not imply direction. There should still be the ability to override either language or direction on any given string value by using the representation found <a href="#single-linguistic-field">above</a>.</p>
 			  
 	 <div class="req" id="bp_default_setting">
         <p class="advisement">Specifications MAY define a mechanism to provide the default language and the default [=string direction=] for all strings in a given resource. However, specifications MUST NOT assume that a resource-wide default is sufficient.  Even if a resource-wide setting is available, it must be possible to use string-specific metadata to override that default.</p>

--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
 
 <body>
 <div id="abstract">
-  <p>This document describes the best practices for identifying language and paragraph direction for strings used on the Web.</p>
+  <p>This document describes the best practices for identifying the language and direction for strings used on the Web.</p>
 </div>
 
 
@@ -60,7 +60,7 @@
 
 <p>The concepts in this document are applicable any time strings are used on the Web, either as part of a formalised data structure, but also where they simply originate from JavaScript scripting or any stored list of strings.</p>
 
-<p><a>Natural language</a> information on the Web depends on and benefits from the presence of language and direction metadata. Along with support for Unicode, mechanisms for including and specifying the <a>paragraph direction</a> and the <a>natural language</a> of spans of text are one of the key internationalization considerations when developing new formats and technologies for the Web.</p>
+<p><a>Natural language</a> information on the Web depends on and benefits from the presence of language and direction metadata. Along with support for Unicode, mechanisms for including and specifying the <a>block direction</a> and the <a>natural language</a> of spans of text are one of the key internationalization considerations when developing new formats and technologies for the Web.</p>
 
 <p>Markup formats, such as HTML and XML, as well as related styling languages, such as CSS and XSL, are reasonably mature and provide support for the interchange and presentation of the world's languages via built-in features. Strings and string-based data formats need similar mechanisms in order to ensure complete and consistent support for the world's languages and cultures.</p>
 
@@ -83,7 +83,7 @@
 
 <p>This section provides short definitions of key terminology necessary to understand the contents of this document. Most of the terms found here are taken from the [[I18N-GLOSSARY]]: they are repeated here for convenience.</p>
 
-<p class="note">If you are unfamiliar with bidirectional or right-to-left text, there is a basic introduction <a href="https://www.w3.org/International/articles/inline-bidi-markup/uba-basics">here</a>. This will give you a basic grasp of how the <a>Unicode Bidirectional Algorithm</a> works and the interplay between it and the <a>paragraph direction</a>, which will stand you in good stead for reading this document. Additional materials can be found in the Internationalization Working Group's <a href="https://www.w3.org/TR/international-specs/#text_direction">Best Practices for Spec Developers</a>.</p>
+<p class="note">If you are unfamiliar with bidirectional or right-to-left text, there is a basic introduction <a href="https://www.w3.org/International/articles/inline-bidi-markup/uba-basics">here</a>. This will give you a basic grasp of how the <a>Unicode Bidirectional Algorithm</a> works and the interplay between it and the <a>block direction</a>, which will stand you in good stead for reading this document. Additional materials can be found in the Internationalization Working Group's <a href="https://www.w3.org/TR/international-specs/#text_direction">Best Practices for Spec Developers</a>.</p>
 
 <p class="definition"><a>Metadata</a> is data <em>about</em> data: it is information included in a data structure that provides additional context, meaning, or presentation. In this document, the function of metadata is to express information about direction and language. [[I18N-GLOSSARY]]</p>
 
@@ -93,11 +93,16 @@
 
 <p class="definition">A <a>serialization agreement</a> is the common understanding between a producer and consumer about the serialization of string metadata: how it is to be understood, serialized, read, transmitted, removed, etc. [[I18N-GLOSSARY]]</p>
 
-<p class="definition"><a>Paragraph direction</a>. The initial base direction of a paragraph or string, which resolves to either <em>left-to-right</em> or <em>right-to-left</em>. The paragraph direction may be overridden by nested, embedding controls that change the direction for an inline range of text, but the paragraph direction sets the starting point which the <cite>Unicode Bidirectional Algorithm</cite> [[UAX9]] uses to calculate the direction of the embedded levels. [[I18N-GLOSSARY]]</p>
 
-<p>In this document we are concerned with identifying the <a>paragraph direction</a> of a whole string and how to transmit and apply the paragraph direction when displaying strings in various contexts. We do not talk about how to determine the direction or display of runs of text within a string.</p>
+<p>The <cite>Unicode Bidirectional Algorithm</cite> [[UAX9]], also known as <em>UBA</em>, defines the concept of a [=paragraph direction=]. This is the initial base direction of a "paragraph", and resolves to either <em>left-to-right</em> or <em>right-to-left</em>. The term "paragraph" has a specific meaning internal to UBA. In the context of this document, the term is misleading, because generally strings and other data on the Web are not "paragraphs of text" in some document format. In this document, we generally use the following two more specific terms:</p>
 
-<p>The <a>bidi algorithm</a> is primarily focused on arranging adjacent characters, based on character properties. The <a>paragraph direction</a> dictates (a) the visual order and direction in which runs of strongly-typed <a>LTR</a> and <a>RTL</a> characters are displayed, and (b) where there are weakly-directional or neutral characters, such as punctuation, the placement of those items relative to the other content.</p>
+<p class="definition"><dfn>Block direction</dfn>. The initial base direction of a block of text, which resolves to either <em>left-to-right</em> or <em>right-to-left</em>. A block refers to a unit of text as a whole, such as a paragraph in a document or a string in a data file. The name "block" is chosen as a contrast to <em>inline direction</em>. Unicode calls this value the [=paragraph direction=]. [[I18N-GLOSSARY]]</p>
+
+<p class="definition"><dfn>String direction</dfn>. The [=block direction=] specifically of a string. Strings transmitted inside various data structures are often inserted into a block (such as a paragraph). In such a case, the string direction is needed as part of the [=bidi isolation=] of the string.</p>
+
+<p>In this document we are concerned with identifying the <a>string direction</a> of a whole string and how to transmit and apply the string direction when displaying strings in various contexts. We do not talk about how to determine the direction or display of runs of text within a string.</p>
+
+<p>The <a>bidi algorithm</a> is primarily focused on arranging adjacent characters, based on character properties. The <a>block direction</a> dictates (a) the visual order and direction in which runs of strongly-typed <a>LTR</a> and <a>RTL</a> characters are displayed, and (b) where there are weakly-directional or neutral characters, such as punctuation, the placement of those items relative to the other content.</p>
 
 </section>
  
@@ -108,26 +113,26 @@
   
 <section id="producers">  
   <h4>Producers</h4>  
-  <p>A string can be created in a number of ways, including a content author typing strings into a plain text editor, text message, or editing tool; or a script scraping text from web pages; or acquisition of an existing set of strings from another application or repository. In the data formats under consideration in this document, many strings come from back end data repositories or databases of various kinds. Sources of strings may provide an interface, API, or metadata that includes information about the <a>paragraph direction</a> and language of the data. Some also provide a suitable default for when the direction or language is not provided or specified. In this document, the <b class="newterm">producer</b> of a string is the source, be it a human or a mechanism, that creates or provides a string for storage or transmission.</p>
-  <p>When a  string is created, it's necessary to (a) detect or capture the appropriate language and <a>paragraph direction</a> to be associated with the string, and (b) take steps, where needed, to set the string up in a way that stores and communicates the language and <a>paragraph direction</a>.</p>
-  <p>For example, in the case of a string that is extracted from an HTML form, the <a>paragraph direction</a> can be detected from the computed value of the form's field. Such a value could be inherited from an earlier element, such as the <code class="kw" translate="no">html</code> element, or set using markup or styling on the <code class="kw" translate="no">input</code> element itself. The user could also set the direction of the text by <a href="https://www.w3.org/International/questions/qa-html-dir#userexplicit">using  keyboard shortcut keys</a> to change the direction of the form field. The <code class="kw" translate="no">dirname</code> attribute provides a way of automatically communicating that value with a form submission.</p>
+  <p>A string can be created in a number of ways, including a content author typing strings into a plain text editor, text message, or editing tool; or a script scraping text from web pages; or acquisition of an existing set of strings from another application or repository. In the data formats under consideration in this document, many strings come from back end data repositories or databases of various kinds. Sources of strings may provide an interface, API, or metadata that includes information about the <a>string direction</a> and language of the data. Some also provide a suitable default for when the direction or language is not provided or specified. In this document, the <b class="newterm">producer</b> of a string is the source, be it a human or a mechanism, that creates or provides a string for storage or transmission.</p>
+  <p>When a  string is created, it's necessary to (a) detect or capture the appropriate language and <a>string direction</a> to be associated with the string, and (b) take steps, where needed, to set the string up in a way that stores and communicates the language and <a>string direction</a>.</p>
+  <p>For example, in the case of a string that is extracted from an HTML form, the <a>string direction</a> can be detected from the computed value of the form's field. Such a value could be inherited from an earlier element, such as the <code class="kw" translate="no">html</code> element, or set using markup or styling on the <code class="kw" translate="no">input</code> element itself. The user could also set the direction of the text by <a href="https://www.w3.org/International/questions/qa-html-dir#userexplicit">using  keyboard shortcut keys</a> to change the direction of the form field. The <code class="kw" translate="no">dirname</code> attribute provides a way of automatically communicating that value with a form submission.</p>
   <p>Similarly, language information in an HTML form  would typically be inherited from the <code class="kw" translate="no">lang</code> attribute on the <code class="kw" translate="no">html</code> tag, or an ancestor element in the tree with a <code class="kw" translate="no">lang</code> attribute.</p>
-  <p>If the producer of the string is receiving the string from a location where it was stored by another producer, and where the <a>paragraph direction</a> and language has already been established, the producer needs to understand that the language and paragraph direction has already been set, and understand how to convert or encode that information for its consumers.</p>
+  <p>If the producer of the string is receiving the string from a location where it was stored by another producer, and where the <a>string direction</a> and language has already been established, the producer needs to understand that the language and string direction has already been set, and understand how to convert or encode that information for its consumers.</p>
 </section>
 
 
 <section id="consumers">
   <h4>Consumers</h4>
-  <p>A <b class="newterm">consumer</b> is an application or process that receives a string for processing and possibly places it into a context where it will be exposed to a user. For display purposes, it must ensure that the <a>paragraph direction</a> and language of the string is correctly applied to the string in that context. For processing purposes, it must at least persist the language and direction and may need to use the language and direction data in order to perform language-specific operations.</p>
-  <p>Displaying the string usually involves applying the <a>paragraph direction</a> and language by constructing additional markup, adding control codes, or setting display properties. This indicates to rendering software the <a>paragraph direction</a> or language that should be applied to the string in this display context to get the string to appear correctly. For both language and direction, it must make clear the boundaries for the range of text to which the language applies. For text direction, it must also isolate embedded strings from the surrounding text to avoid spill-over effects of the bidi algorithm [[UAX9]].</p>
+  <p>A <b class="newterm">consumer</b> is an application or process that receives a string for processing and possibly places it into a context where it will be exposed to a user. For display purposes, it must ensure that the <a>block direction</a> and language of the string is correctly applied to the string in that context. For processing purposes, it must at least persist the language and direction and may need to use the language and direction data in order to perform language-specific operations.</p>
+  <p>Proper display of the string involves supplying the <a>string direction</a> and language to the rendering document or process by applying additional markup, adding control codes, or setting display properties. This indicates to rendering software the <a>string direction</a> or language that should be applied to the string in this display context to get the string to appear correctly. For both language and direction, it must make clear the boundaries for the range of text to which the language applies. For text direction, it must also isolate embedded strings from the surrounding text to avoid spill-over effects of the bidi algorithm [[UAX9]].</p>
   <p>Note that a consumer of one document format might be a <a>producer</a> of another document format.</p>
 </section>
 
 
 <section id="agreements">
   <h4>Serialization Agreements</h4>
-  <p>Between any <a>producer</a> and <a>consumer</a>, there needs to be an <dfn data-lt="agreement|serialization agreement">agreement</dfn> about what the document format contains and what the data in each field or attribute means. Any time a producer of a string takes special steps to collect and communicate information about the <a>paragraph direction</a> or language of that string, it must do so with the expectation that the consumer of the string will understand how the producer encoded this information. </p>
-  <p>If no action is taken by the producer, the consumer must still decide what rules to follow in order to decide on the appropriate <a>paragraph direction</a> and language, even if it is only to provide some form of default value.</p>
+  <p>Between any <a>producer</a> and <a>consumer</a>, there needs to be an <dfn data-lt="agreement|serialization agreement">agreement</dfn> about what the document format contains and what the data in each field or attribute means. Any time a producer of a string takes special steps to collect and communicate information about the <a>string direction</a> or language of that string, it must do so with the expectation that the consumer of the string will understand how the producer encoded this information. </p>
+  <p>If no action is taken by the producer, the consumer must still decide what rules to follow in order to decide on the appropriate <a>string direction</a> and language, even if it is only to provide some form of default value.</p>
   <p>In some systems or document formats, the necessary behaviour of the producers and consumers of a string are fully specified. In others, such agreements are not available; it is up to users to provide an agreement for how to encode, transmit, and later decode the necessary language or direction information. Low level specifications, such as JSON, do not provide a string metadata structure by default, so any document formats based on these need to provide the "agreement" themselves.</p>
 </section>
 </section>
@@ -137,7 +142,7 @@
 
 <p>The Web uses strings and character sequences to encode most data. Leaving aside different data types (such as numbers, time values, or binary data serializations such as <code>base64</code>), there are still values that are defined as using a string data type but which are not intended for use as <a>natural language</a> data values. For example, the <a>syntactic content</a> defined by a specification, such as the reserved keywords in CSS or the names of the various definitions in a WebIDL document, are not part of the <a>localizable text</a> of their respective document formats or protocols.</p>
 
-<p>Many specifications also allow users to provide <a>user-supplied values</a> inside of a given namespace or document format. For example, SSIDs on a Wifi network are user-defined. So too are class names in a CSS stylesheet. Most specifications allow (and are encouraged to allow) a wide range of Unicode characters in these names. Most users choose values that are recognizable as words in one or another natural language, as doing so makes the values easier to work with. However, even though these strings consist of words in a natural language, these types of strings are not considered <a>localizable text</a> and do not need to be encumbered with additional metadata related to language or <a>paragraph direction</a>. Usually they are merely identifiers that enable a computer to match the values.</p>
+<p>Many specifications also allow users to provide <a>user-supplied values</a> inside of a given namespace or document format. For example, SSIDs on a Wifi network are user-defined. So too are class names in a CSS stylesheet. Most specifications allow (and are encouraged to allow) a wide range of Unicode characters in these names. Most users choose values that are recognizable as words in one or another natural language, as doing so makes the values easier to work with. However, even though these strings consist of words in a natural language, these types of strings are not considered <a>localizable text</a> and do not need to be encumbered with additional metadata related to language or <a>string direction</a>. Usually they are merely identifiers that enable a computer to match the values.</p>
 
 <p>A sometimes-useful test is that if replacing the identifier with an arbitrary string such as <code>tK0001.37B</code> would still be allowed, functional, and "normal", then it's not <a>localizable text</a>.</p>
 
@@ -147,14 +152,14 @@
 
 <section>
 <h2 id="bp_and-reco">Best Practices, Recommendations, and Gaps</h2>
-<p>This section consists of the Internationalization (I18N) Working Group's set of best practices for identifying language and <a>paragraph direction</a> in data formats on the Web. In some cases, there are gaps in existing standards, where the recommendations of the I18N WG require additional standardization or there might be barriers to full adoption.</p>
+<p>This section consists of the Internationalization (I18N) Working Group's set of best practices for identifying language and <a>string direction</a> in data formats on the Web. In some cases, there are gaps in existing standards, where the recommendations of the I18N WG require additional standardization or there might be barriers to full adoption.</p>
 
-<p>The main issue is how to establish a common <a>serialization agreement</a> between producers and consumers of data values so that each knows how to encode, find, and interpret the language and <a>paragraph direction</a> of each data field. The use of metadata for supplying both the language and <a>paragraph direction</a> of natural language string fields ensures that the necessary information is present, can be supplied and extracted with the minimal amount of processing, and does not require producers or consumers to scan or alter the data.</p>
+<p>The main issue is how to establish a common <a>serialization agreement</a> between producers and consumers of data values so that each knows how to encode, find, and interpret the language and <a>string direction</a> of each data field. The use of metadata for supplying both the language and <a>string direction</a> of natural language string fields ensures that the necessary information is present, can be supplied and extracted with the minimal amount of processing, and does not require producers or consumers to scan or alter the data.</p>
 
 <p>The most basic best practice, which the Internationalization Working Group looks for in every specification, is:</p>
 
 <div class="req" id="bp-determine">
-	<p class="advisement">For any string field containing natural language text, it MUST be possible to determine the language and <a>paragraph direction</a> of that specific string. Such determination SHOULD use metadata at the string or document level and SHOULD NOT depend on heuristics.</p>
+	<p class="advisement">For any string field containing natural language text, it MUST be possible to determine the language and <a>string direction</a> of that specific string. Such determination SHOULD use metadata at the string or document level and SHOULD NOT depend on heuristics.</p>
 </div>
 
 <section>
@@ -178,7 +183,7 @@
           </aside>
 			  
 		  <div class="req" id="bp-non-linguistic-defaults">
-		     <p class="advisement">If a <a>consumer</a> is required to assign a language tag to some non-linguistic data, the language tag <code>zxx</code> (Non-Linguistic) SHOULD be used. If a <a>consumer</a> is required to assign a <a>paragraph direction</a> to such data, the value <code>auto</code> SHOULD be used.</p>
+		     <p class="advisement">If a <a>consumer</a> is required to assign a language tag to some non-linguistic data, the language tag <code>zxx</code> (Non-Linguistic) SHOULD be used. If a <a>consumer</a> is required to assign a <a>string direction</a> to such data, the value <code>auto</code> SHOULD be used.</p>
 		  </div>
 		  
   
@@ -212,10 +217,10 @@
 		   <h4>Single-Language Localizable Text Field</h4>
 			  
            <div class="req" id="bp_lang_field_based_metadata">
-              <p class="advisement">Use field-based metadata or string datatypes to indicate the language and the <a>paragraph direction</a> for individual <a>localizable text</a> values.</p>
+              <p class="advisement">Use field-based metadata or string datatypes to indicate the language and the <a>string direction</a> for individual <a>localizable text</a> values.</p>
            </div>
 
-		  <p>For <a>localizable text</a> fields that appear in a single language, use a data structure to represent the value. The recommended representation is an object with three fields. The field <code>value</code> contains the actual string. The field <code>lang</code> contains a <a>valid</a> [[BCP47]] language tag. The field <code>dir</code> contains the string's <a>paragraph direction</a> (one of the values <code>ltr</code>, <code>rtl</code>, or <code>auto</code>).</p>
+		  <p>For <a>localizable text</a> fields that appear in a single language, use a data structure to represent the value. The recommended representation is an object with three fields. The field <code>value</code> contains the actual string. The field <code>lang</code> contains a <a>valid</a> [[BCP47]] language tag. The field <code>dir</code> contains the string's <a>string direction</a> (one of the values <code>ltr</code>, <code>rtl</code>, or <code>auto</code>).</p>
 		  
 		  <aside class="example" title="Example of a localizable text field">
 		  <pre class="json" id="localizable-text-field">
@@ -227,13 +232,13 @@
 		  </pre>
 		  </aside>
 
-          <p>Use of heuristics to determine language or <a>paragraph direction</a> will always fail for certain cases, and there needs to be a way to provide the correct outcome for those strings. Assignment of <a href="#metadata">metadata</a> (either as a resource-wide default, or in a string-specific label) is an intentional act that removes the need to guess the outcome by applying heuristics.</p>
+          <p>Use of heuristics to determine language or <a>string direction</a> will always fail for certain cases, and there needs to be a way to provide the correct outcome for those strings. Assignment of <a href="#metadata">metadata</a> (either as a resource-wide default, or in a string-specific label) is an intentional act that removes the need to guess the outcome by applying heuristics.</p>
 
-          <p>The use of <a href="#metadata">metadata</a> for indicating <a>paragraph direction</a> is preferred because it avoids requiring the consumer to interpolate the direction using methods such as <a href="#firststrong">first strong</a> or use of methods which require modification of the data itself (such as the <a href="#rlm">insertion of RLM/LRM markers</a> or <a href="#paired">bidirectional controls</a>).</p>
+          <p>The use of <a href="#metadata">metadata</a> for indicating <a>block direction</a> is preferred because it avoids requiring the consumer to interpolate the direction using methods such as <a href="#firststrong">first strong</a> or use of methods which require modification of the data itself (such as the <a href="#rlm">insertion of RLM/LRM markers</a> or <a href="#paired">bidirectional controls</a>).</p>
 
 <aside class="note">
-    <p>Some schema languages, such as the RDF suite of specifications, have no built-in mechanism for associating [=paragraph direction=] metadata with natural language string values. It is up to specifications that use these specifications to define structures and adopt best practices that result in clean interchange of language and direction metadata.</p>
-    <p>For example, [[JSON-LD]] provides a document-level [=paragraph direction=] using the <code class="kw" translate="no">@context</code> mechanism and defines the <code class="kw" translate="no">i18n</code> namespace as an extension of existing RDF datatypes which can be used to set the language, [=paragraph direction=], or both of string values.</p>
+    <p>Some schema languages, such as the RDF suite of specifications, have no built-in mechanism for associating [=string direction=] metadata with natural language string values. It is up to specifications that use these specifications to define structures and adopt best practices that result in clean interchange of language and direction metadata.</p>
+    <p>For example, [[JSON-LD]] provides a document-level [=block direction=] using the <code class="kw" translate="no">@context</code> mechanism and defines the <code class="kw" translate="no">i18n</code> namespace as an extension of existing RDF datatypes which can be used to set the language, [=string direction=], or both of string values.</p>
 </aside>
 
 
@@ -248,10 +253,10 @@
 	<section id="language-defaults">
 	<h4 id="resource_wide_default">Resource-wide Defaults</h4>
 			  
-	<p>When a document contains a number of natural language strings (and particularly if those string are all in the same language), using the localized string representation described above can become inefficient. To reduce the complexity of encoding these strings, specifications can establish a document-level default for language and base paragraph direction. These are separate values, as language does not imply direction. There should still be the ability to override either language or direction on any given string value by using the representation found <a href="#single-linguistic-field">above</a>.</p>
+	<p>When a document contains a number of natural language strings (and particularly if those string are all in the same language), using the localized string representation described above can become inefficient. To reduce the complexity of encoding these strings, specifications can establish a document-level default for language and [=block direction=]. These are separate values, as language does not imply direction. There should still be the ability to override either language or direction on any given string value by using the representation found <a href="#single-linguistic-field">above</a>.</p>
 			  
 	 <div class="req" id="bp_default_setting">
-        <p class="advisement">Specifications MAY define a mechanism to provide the default language and the default [=paragraph direction=] for all strings in a given resource. However, specifications MUST NOT assume that a resource-wide default is sufficient.  Even if a resource-wide setting is available, it must be possible to use string-specific metadata to override that default.</p>
+        <p class="advisement">Specifications MAY define a mechanism to provide the default language and the default [=string direction=] for all strings in a given resource. However, specifications MUST NOT assume that a resource-wide default is sufficient.  Even if a resource-wide setting is available, it must be possible to use string-specific metadata to override that default.</p>
      </div>
 
 	 <p>If your specification defines its own document level defaults, provide two optional fields:</p>
@@ -260,7 +265,7 @@
 		<p class="advisement">A document-level default language field SHOULD be called <code>language</code> and SHOULD be specified to contain a <a>valid</a> [[BCP47]] language tag. Specifications SHOULD specify that implementations are only require to check if a [[BCP47]] language tag is <a>well-formed</a>.</p>
 	 </div>
      <div class="req" id="bp-document-direction-default">
-		<p class="advisement">A document-level default <a>paragraph direction</a> field SHOULD be called <code>direction</code> and support the values <code>ltr</code>, <code>rtl</code>, or <code>auto</code>.</p>
+		<p class="advisement">A document-level default <a>block direction</a> field SHOULD be called <code>direction</code> and support the values <code>ltr</code>, <code>rtl</code>, or <code>auto</code>.</p>
 	</div>
 
     <aside class="example" title="Example of document level defaults">
@@ -279,7 +284,7 @@
 
     <p>Exceptions to the default are always a possibility, so it needs to be possible for users to override the default on a string-by-string basis.</p>
 
-    <p>First-strong heuristics are not applied to strings when the direction has been set externally using metadata. Even if a strongly directional character, such as <span class="codepoint" translate="no"><img alt="RLM" src="images/200F.png"><code class="uname">U+200F RIGHT-TO-LEFT MARK</code></span>, has been prepended to a string, resource-wide default metadata can override the presentation of the string in ways that result in <a>spillover</a> effects. Therefore content needs to be able to provide string-level metadata to override the default for strings whose <a>paragraph direction</a> does not match the resource-wide default.</p>
+    <p>First-strong heuristics are not applied to strings when the direction has been set externally using metadata. Even if a strongly directional character, such as <span class="codepoint" translate="no"><img alt="RLM" src="images/200F.png"><code class="uname">U+200F RIGHT-TO-LEFT MARK</code></span>, has been prepended to a string, resource-wide default metadata can override the presentation of the string in ways that result in <a>spillover</a> effects. Therefore content needs to be able to provide string-level metadata to override the default for strings whose <a>string direction</a> does not match the resource-wide default.</p>
 		  
 	<p>For specifications that can make use of the [[JSON-LD]] <code>@context</code> mechanism, use the <code>@language</code> and <code>@direction</code> fields to supply the document level defaults.</p>
               
@@ -345,11 +350,11 @@
 </section>
 
 <div class="req" id="bp_use_heuristics_1">
-<p class="advisement">For the case where the paragraph direction is not known, specify that consumers should use first-strong heuristics to identify the [=paragraph direction=] of each string.</p>
+<p class="advisement">For the case where the [=string direction=] is not known, specify that consumers should use first-strong heuristics to identify the [=string direction=] of each string.</p>
 </div>
 
 <p>If metadata is not available, consumers of strings should use heuristics, preferably based on the Unicode Standard's first-strong detection algorithm, to detect the base direction of a string.</p>
-<p>The <a href="#firststrong">first-strong algorithm</a> looks for the first strongly-directional character in a string (skipping certain preliminary substrings), and assumes that it represents the <a>paragraph direction</a> of the string as a whole. However, the first strong directional character doesn't always coincide with the actual or desired [=paragraph direction=] of the string as a whole, so it should be possible to  provide metadata, where needed, to address this problem.</p>
+<p>The <a href="#firststrong">first-strong algorithm</a> looks for the first strongly-directional character in a string (skipping certain preliminary substrings), and assumes that it represents the [=string direction=] of the string as a whole. However, the first strong directional character doesn't always coincide with the actual or desired [=string direction=] of the string as a whole, so it should be possible to  provide metadata, where needed, to address this problem.</p>
 
 <div class="req" id="bp_using_rlm_lrm">
 <p class="advisement">If relying on first-strong heuristics, allow content developers to use RLM/LRM at the beginning of a string where it is necessary to force a particular base direction, but do not prepend one of these characters to existing strings.</p>
@@ -359,14 +364,14 @@
 <p class="advisement">Do not rely on the availability of RLM/LRM formatting characters in most cases.</p>
 </div>
 
-<p>If string data is being provided by users or content developers in web forms or other simple environments, users may not be able to enter these formatting characters.  In fact, most users will probably be unaware that such characters exist, or how to use them.  A web form can render their use unnecessary for immediate inspection if it sets the <a>paragraph direction</a> for the input (which it should).</p>
+<p>If string data is being provided by users or content developers in web forms or other simple environments, users may not be able to enter these formatting characters.  In fact, most users will probably be unaware that such characters exist, or how to use them.  A web form can render their use unnecessary for immediate inspection if it sets the <a>block direction</a> for the input (which it should).</p>
 
 
 <div class="req" id="bp_inferring_from_language">
-<p class="advisement">Specifications SHOULD NOT allow a <a>paragraph direction</a> to be <a href="#script_subtag">interpolated from available language metadata</a> unless direction metadata is not available and cannot otherwise be provided.</p>
+<p class="advisement">Specifications SHOULD NOT allow a <a>string direction</a> to be <a href="#script_subtag">interpolated from available language metadata</a> unless direction metadata is not available and cannot otherwise be provided.</p>
 </div>
 
-<p>Not all resources make use of the available metadata mechanisms. The script subtag of a language tag (or the "likely" script subtag based on [[BCP47]] and [[LDML]]) can sometimes be used to infer a [=paragraph direction=] when other data is not available. Using language information is a "last resort" and specifications SHOULD NOT use it as the primary way of indicating paragraph direction: make the effort to provide for metadata.</p>
+<p>Not all resources make use of the available metadata mechanisms. The script subtag of a language tag (or the "likely" script subtag based on [[BCP47]] and [[LDML]]) can sometimes be used to infer a [=block direction=] or [=string direction=] when other data is not available. Using language information is a "last resort" and specifications SHOULD NOT use it as the primary way of indicating [=block direction=]: make the effort to provide for metadata.</p>
 
 
 <section id="technology_specific_solutions">
@@ -403,7 +408,7 @@
 <h3>Strings that are part of a legacy protocol or format</h3>
 
 <div class="req" id="bp_legacy_fmt_dir">
-   <p class="advisement">For strings that cannot specify direction due to legacy format reasons, specifications SHOULD specify that the <a>paragraph direction</a> of each string depends on first-strong heuristics.</p>
+   <p class="advisement">For strings that cannot specify direction due to legacy format reasons, specifications SHOULD specify that the <a>string direction</a> of each string depends on first-strong heuristics.</p>
 </div>
 
 <div class="req" id="bp_legacy_fmt_nonlang">
@@ -438,14 +443,14 @@
 <section>
 <h2 id="defining_bidi_keywords">Defining Bidirectional Keywords in Specifications</h2>
 
-<p>A specification for a document format or protocol that includes natural language text values will need to define a data field or attribute to store the <a>paragraph direction</a> for each natural language content value. These definitions need to be consistent across the Web in order to ensure interoperability, because <a>consumers</a> of one document format will need to map the <a>paragraph direction</a> for values they receive to fields that they produce or will need to control the <a>paragraph direction</a> of each string when displaying the content. This section describes how to provide such a definition along with the specific content to use.</p>
+<p>A specification for a document format or protocol that includes natural language text values will need to define a data field or attribute to store the <a>block direction</a> for each natural language content value. These definitions need to be consistent across the Web in order to ensure interoperability, because <a>consumers</a> of one document format will need to map the <a>block direction</a> for values they receive to fields that they produce or will need to control the <a>string direction</a> of each string when displaying the content. This section describes how to provide such a definition along with the specific content to use.</p>
 
-<p>There are two common use cases for defining content direction: (i) defining a <a>directional metadata field</a> for storing and transmitting the <a>paragraph direction</a> as a field in a data structure or (ii) defining a <a>direction attribute</a> to associate a <a>paragraph direction</a> with a given piece of natural language content.</p>
+<p>There are two common use cases for defining content direction: (i) defining a <a>directional metadata field</a> for storing and transmitting the <a>string direction</a> as a field in a data structure or (ii) defining a <a>direction attribute</a> to associate a <a>block direction</a> with a given piece of natural language content.</p>
 
-<p class="definition"><dfn data-lt="directional metadata field|direction field">Directional metadata field</dfn>. A directional metadata field (or <strong>direction field</strong> for short) is a field in a data structure used to associate a paragraph direction with a given natural language string field or data value.</p>
+<p class="definition"><dfn data-lt="directional metadata field|direction field">Directional metadata field</dfn>. A directional metadata field (or <strong>direction field</strong> for short) is a field in a data structure used to associate a [=string direction=] with a given natural language string field or data value.</p>
 
 <aside class="example" id="example-direction-metadata">
-	<p><strong>Example of a <a>direction field</a>.</strong> In this JSON fragment, the <code>title</code> structure has a field <code>direction</code> which represents the <a>paragraph direction</a> to use for the field <code>value</code>.</p>
+	<p><strong>Example of a <a>direction field</a>.</strong> In this JSON fragment, the <code>title</code> structure has a field <code>direction</code> which represents the <a>string direction</a> to use for the field <code>value</code>.</p>
 <pre class="json">"title": {
 	"value": "HTML و CSS: تصميم و إنشاء مواقع الويب",
 	"direction": "rtl",
@@ -453,7 +458,7 @@
 }</pre>
 </aside>
 
-<p class="definition"><dfn data-lt="direction attribute">Direction attribute</dfn>. A direction attribute is a field or value, usually represented by an attribute in markup languages, that provides the paragraph direction of the associated natural language string content.</p>
+<p class="definition"><dfn data-lt="direction attribute">Direction attribute</dfn>. A direction attribute is a field or value, usually represented by an attribute in markup languages, that provides the [=string direction=] of the associated natural language string content.</p>
 
 <aside class="example">
 
@@ -486,9 +491,9 @@
 
 <p>The value <code class="kw" translate="no">rtl</code> indicates a direction of right-to-left, in exactly the same manner indicated by <a href="https://www.w3.org/TR/css-writing-modes/#direction">CSS writing modes</a> [[CSS-WRITING-MODES-4]]</p>
 
-<p>The value <code class="kw" translate="no">auto</code> indicates that the user agent uses the <a href="https://html.spec.whatwg.org/multipage/dom.html#the-dir-attribute">algorithm</a> for <code class="kw" translate="no">auto</code> defined by [[HTML]] to determine the base paragraph direction. This heuristic looks for the first character with a strong directionality, in a manner analogous to the Paragraph Level determination in the bidirectional algorithm [[UAX9]].</p>
+<p>The value <code class="kw" translate="no">auto</code> indicates that the user agent uses the <a href="https://html.spec.whatwg.org/multipage/dom.html#the-dir-attribute">algorithm</a> for <code class="kw" translate="no">auto</code> defined by [[HTML]] to determine the [=block direction=] ("[=paragraph direction=]"). This heuristic looks for the first character with a strong directionality, in a manner analogous to the Paragraph Level determination in the bidirectional algorithm [[UAX9]].</p>
 
-<p>When <code class="kw" translate="no">auto</code> is applied to multiple fields or to a document as a whole, it means that the direction should be individually derived for each field (with string-specific metadata providing an override for cases that cannot be determined automatically). It can be useful for labelling a group of mixed direction strings, when the <a>paragraph direction</a> of most strings can be reliably determined using the first-strong heuristics. Whenever possible, the actual <a>paragraph direction</a> (<code class="kw" translate="no">ltr</code> or <code class="kw" translate="no">rtl</code>) of individual strings should be stored or exchanged instead of <code class="kw" translate="no">auto</code>. Omitting the <a>direction field</a> is preferable when the value is truly unknown.</p>
+<p>When <code class="kw" translate="no">auto</code> is applied to multiple fields or to a document as a whole, it means that the direction should be individually derived for each field (with string-specific metadata providing an override for cases that cannot be determined automatically). It can be useful for labelling a group of mixed direction strings, when the <a>string direction</a> of most strings can be reliably determined using the first-strong heuristics. Whenever possible, the actual <a>string direction</a> (<code class="kw" translate="no">ltr</code> or <code class="kw" translate="no">rtl</code>) of individual strings should be stored or exchanged instead of <code class="kw" translate="no">auto</code>. Omitting the <a>direction field</a> is preferable when the value is truly unknown.</p>
 
 </section>
 
@@ -521,7 +526,7 @@
 
 
 <aside class="example">
-<p>Here is the record used in the <a href="#base_example">original example</a> with a record-level default language and default paragraph direction added. It also shows the use of a Localizable string to override the document-level defaults for the <code class="kw">author</code> field. Note that this "worked example" is not valid.</p>
+<p>Here is the record used in the <a href="#base_example">original example</a> with a record-level default language and default [=block direction=] added. It also shows the use of a Localizable string to override the document-level defaults for the <code class="kw">author</code> field. Note that this "worked example" is not valid.</p>
 <pre>
 {
     "@context": { 
@@ -588,15 +593,7 @@
 	<li>Selection of a text-to-speech voice and processor, such as used for accessibility or in a voice-based interface</li>
 </ul>
 
-<p>Similarly, direction metadata is important to the Web. When a string 
-contains text in a script that runs right-to-left (RTL), it must be 
-possible to eventually display that string correctly when it reaches an 
-end user. For that to happen, it is necessary to establish what <a>paragraph 
-direction</a> needs to be applied to the string as a whole. The 
-appropriate paragraph direction cannot always be deduced by simply looking 
-at the string; even where it is possible, the producer and consumer of 
-the string  need to use the same heuristics to interpret the 
-direction.</p>
+<p>Similarly, direction metadata is important to the Web. When a string contains text in a script that runs right-to-left (RTL), it must be possible to eventually display that string correctly when it reaches an end user. For that to happen, it is necessary to establish what <a>string direction</a> needs to be applied to the string as a whole. The appropriate [=string direction=] cannot always be deduced by simply looking at the string; even where it is possible, the producer and consumer of the string  need to use the same heuristics to interpret the direction.</p>
   
 <p>Static content, such as the body of a Web page or the contents of an 
 e-book, often has language or direction information provided by the document format 
@@ -648,7 +645,7 @@ might look something like:</p>
 
 <p>Each of the above is a data field in a database somewhere. There is even information about what language the book is in: (<samp>"language": "ar"</samp>).</p>
 
-<p>A well-internationalized catalog would include additional metadata to what is shown above. That is, for each of the fields containing <a>localizable text</a>, such as the <samp>title</samp> and <samp>authors</samp> fields, there should be language and <a>paragraph direction</a> information stored as metadata. (There may be other values as well, such as pronunciation metadata for sorting East Asian language information.) These metadata values are used by consumers of the data to influence the processing and enable the display of the items in a variety of ways. As the JSON data structure 
+<p>A well-internationalized catalog would include additional metadata to what is shown above. That is, for each of the fields containing <a>localizable text</a>, such as the <samp>title</samp> and <samp>authors</samp> fields, there should be language and <a>string direction</a> information stored as metadata. (There may be other values as well, such as pronunciation metadata for sorting East Asian language information.) These metadata values are used by consumers of the data to influence the processing and enable the display of the items in a variety of ways. As the JSON data structure 
 provides no place to store or exchange these values, it is more difficult to construct internationalized applications.</p>
 
 <p>One work-around might be to encode the values using a mix of HTML and Unicode bidi controls, so that a data value might look like one of the following:</p>
@@ -699,16 +696,16 @@ data in an interchange format is not a good idea. These include:</p>
 
 <section>
 <h3 id="what_consumers_do">What consumers need to do to support direction</h3>
-<p>Given the <a href="">use cases</a> for bidirectional text, it will be clear that a consumer cannot simply insert a string into a target location without some additional work or preparation taking place, first to establish the appropriate <a>paragraph direction</a> for the string being inserted, and secondly to apply bidi isolation around the string.</p>
-<p>This requires the presence of markup or Unicode formatting controls around the string. If the string's [=paragraph direction=] is opposite that of the content into which it is being inserted, the markup or control codes need to tightly wrap the string. Strings that are inserted adjacent to each other all need to be individually wrapped in order to avoid the spillover issues we saw in the previous section.</p>
+<p>Given the <a href="">use cases</a> for bidirectional text, it will be clear that a consumer cannot simply insert a string into a target location without some additional work or preparation taking place, first to establish the appropriate <a>string direction</a> for the string being inserted, and secondly to apply bidi isolation around the string.</p>
+<p>This requires the presence of markup or Unicode formatting controls around the string. If the string's actual direction is opposite that of the content into which it is being inserted, the markup or control codes need to tightly wrap the string. Strings that are inserted adjacent to each other all need to be individually wrapped in order to avoid the spillover issues we saw in the previous section.</p>
 <p>[[HTML5]] provides base direction controls and isolation for any inline element when the <code class="kw" translate="no">dir</code> attribute is used, or when the <code class="kw" translate="no">bdi</code> element is used. When inserting strings into plain text environments, isolating Unicode formatting characters need to be used. (Unfortunately, support for the isolating characters, which the Unicode Standard recommends as the default for plain text/non-markup applications, is still not universal.)</p>
-<p>The trick is to ensure that the direction information provided by the markup or control characters reflects the <a>paragraph direction</a> of the string.</p>
+<p>The trick is to ensure that the direction information provided by the markup or control characters reflects the <a>string direction</a> of the string.</p>
 </section>
 </section>
 
 <section>
-<h2 id="bidi-approaches">Approaches Considered for Identifying the Paragraph Direction</h2>
-<p>The fundamental problem for bidirectional text values is how a <a>consumer</a> of a string will know what [=paragraph direction=] to use for that string when it is eventually displayed to a user. Note that some of these approaches for identifying or estimating the paragraph direction have utility in specific applications and are in use in different specifications such as [[HTML5]]. The issue here is which are appropriate to adopt generally and specify for use as a best practice in document formats.</p>
+<h2 id="bidi-approaches">Approaches Considered for Identifying the [=String Direction=]</h2>
+<p>The fundamental problem for bidirectional text values is how a <a>consumer</a> of a string will know what [=string direction=] to use for that string when it is eventually displayed to a user. Note that some of these approaches for identifying or estimating the direction have utility in specific applications and are in use in different specifications such as [[HTML5]]. The issue here is which are appropriate to adopt generally and specify for use as a best practice in document formats.</p>
 
 <section id="firststrong">
   <h3>First-strong property detection</h3>
@@ -717,12 +714,12 @@ data in an interchange format is not a good idea. These include:</p>
 <h4>How it works</h4>
 <p>A producer doesn't need to do anything.</p>
 <p>The string is stored as it is.</p>
-<p>Consumers must look for the first character in the string with a strong Unicode directional property, and set the paragraph direction to match it. They then take appropriate action  to ensure that the string will be displayed as needed. This is not quite so simple as it may appear, for the following reasons:</p>
+<p>Consumers must look for the first character in the string with a strong Unicode directional property, and set the [=string direction=] to match it. They then take appropriate action  to ensure that the string will be displayed as needed. This is not quite so simple as it may appear, for the following reasons:</p>
 <ol>
 <li>Characters at the start of a string without a strong direction (eg. punctuation, numbers, etc) and isolated sequences (ie. sequences of characters surrounded by RLI/LRI/FSI...PDI formatting characters) within a string must be skipped in order to find the first strong character.</li>
 <li>The detection algorithm needs to be able to handle markup at the start of the string. It needs to be able to tell whether the markup is just string text, or whether the markup needs to be parsed in the target location – in which case it must understand the markup, and understand any direction-related information that is carried in the markup.</li>
 </ol>
-<p>First-strong detection is only needed where the required [=paragraph direction=] is not already known. If direction is indicated for a string by metadata, either string-specific or via a resource-wide declaration, then first-strong heuristics should not be invoked. For example, first-strong heuristics would produce the wrong result for a string such as &quot;<span lang="ar" dir="rtl">HTML و CSS: تصميم و إنشاء مواقع الويب</span>&quot;. This can be corrected using metadata, the use of which signifies informed intention, and you would not need or want to apply heuristics that would then make the result incorrect.</p>
+<p>First-strong detection is only needed where the required [=string direction=] is not already known. If direction is indicated for a string by metadata, either string-specific or via a resource-wide declaration, then first-strong heuristics should not be invoked. For example, first-strong heuristics would produce the wrong result for a string such as &quot;<span lang="ar" dir="rtl">HTML و CSS: تصميم و إنشاء مواقع الويب</span>&quot;. This can be corrected using metadata, the use of which signifies informed intention, and you would not need or want to apply heuristics that would then make the result incorrect.</p>
 <p>However, if there is no mechanism for the application of metadata, or if there is such a mechanism but the content developer omitted to use it, then first-strong heuristics can be helpful to establish <a>base direction</a> in many, though not all, cases. The application of strongly-directional formatting characters can help produce correct results for plain text strings such as the example just quoted, but it is not always possible to apply those (see [[[#rlm]]]).</p>
 </section>
 
@@ -782,14 +779,14 @@ data in an interchange format is not a good idea. These include:</p>
 <p>Metadata indicating the default direction for all the strings in a resource could also be set using an appropriate field.</p>
 <section>
 <h4>How it works</h4>
-<p>A producer ascertains the [=paragraph direction=] of the string and adds that to a metadata field that accompanies the string when it is stored or transmitted.</p>
+<p>A producer ascertains the [=string direction=] of the string and adds that to a metadata field that accompanies the string when it is stored or transmitted.</p>
 <p>There are several approaches to using metadata:</p>
 <ol>
-<li>Label every string with a <a>paragraph direction</a>.</li>
-<li>Provide a document-level default for <a>paragraph direction</a> and only include metadata for strings whose value is different. The value <code>auto</code> is used when the direction of a string is not known.</li>
+<li>Label every string with a <a>string direction</a>.</li>
+<li>Provide a document-level default for <a>block direction</a> and only include metadata for strings whose value is different. The value <code>auto</code> is used when the direction of a string is not known.</li>
 <li>Rely on the consumer to do <a href="#firststrong">first-strong detection</a>, and label only those strings which would produce the wrong result (that is, a right-to-left string that starts with left-to-right strong characters).</li>
 </ol>
-<p>If storing or transmitting a set of strings at a time, it helps to have a field for the resource as a whole that sets a global, default <a>paragraph direction</a> which can be inherited by all strings in the resource. Note that in addition to a global field, you still need the possibility of attaching string-specific metadata fields in cases where a string's <a>paragraph direction</a> is not the same as the default value. The [=paragraph direction=] set on an individual string must always override the default.</p>
+<p>If storing or transmitting a set of strings at a time, it helps to have a field for the resource as a whole that sets a global, default <a>string direction</a> which can be inherited by all strings in the resource. Note that in addition to a global field, you still need the possibility of attaching string-specific metadata fields in cases where a string's <a>string direction</a> is not the same as the default value. The [=string direction=] set on an individual string must always override the default.</p>
 <p>Consumers would need to understand how to read the metadata sent with a string, and would need to apply first-strong heuristics in the absence of metadata.</p>
 
 <p>The use of the <a href="#use-the-localizable-data-structure">Localizable</a> dictionary structure is RECOMMENDED for individual values in JSON-based document formats, as it combines both language and direction metadata and, if consistently adopted, makes interchange between different formats easier.</p>
@@ -802,8 +799,8 @@ data in an interchange format is not a good idea. These include:</p>
 <section>
 <h4>Advantages</h4>
 
-<p>Passing metadata as separate data value from the string provides a simple, effective and efficient method of communicating the intended [=paragraph direction=] without affecting the actual content of the string.</p>
-<p>If every string is labelled for direction, or the direction for all strings can be ascertained by applying the global setting and any string-specific deviations, it avoids the need to inspect and run heuristics to determine each separate string's [=paragraph direction=].</p>
+<p>Passing metadata as separate data value from the string provides a simple, effective and efficient method of communicating the intended [=string direction=] without affecting the actual content of the string.</p>
+<p>If every string is labelled for direction, or the direction for all strings can be ascertained by applying the global setting and any string-specific deviations, it avoids the need to inspect and run heuristics to determine each separate string's [=string direction=].</p>
 </section>
 
 
@@ -828,14 +825,14 @@ data in an interchange format is not a good idea. These include:</p>
 
 <section>
 <h4>How it works</h4>
-<p>A producer ascertains the  [=paragraph direction=] of the string and adds an marker character (either <span class="unicode">U+200F RIGHT-TO-LEFT MARK</span> (RLM) or <span class="unicode">U+200E LEFT-TO-RIGHT MARK</span> (LRM)) to the beginning of the string. The marker is not functional, ie. it will not automatically apply a base direction to the string that can be used by the consumer, it is simply a marker.</p>
+<p>A producer ascertains the  [=string direction=] of the string and adds an marker character (either <span class="unicode">U+200F RIGHT-TO-LEFT MARK</span> (RLM) or <span class="unicode">U+200E LEFT-TO-RIGHT MARK</span> (LRM)) to the beginning of the string. The marker is not functional, ie. it will not automatically apply a base direction to the string that can be used by the consumer, it is simply a marker.</p>
 <p>There are a number of possible approaches:</p>
 <ol>
 <li>Add a marker to every string (not recommended).</li>
 <li>Rely on the consumer to do <a href="#firststrong">first-strong detection</a>, and add a marker to only those strings which would produce the wrong result (eg. a RTL string that starts with LTR strong characters).</li>
 <li>Assume a default of LTR (no marker), and apply only RLM markers.</li>
 </ol>
-<p>Consumers apply first-strong heuristics to detect the paragraph direction for the string. The RLM and LRM characters are strongly typed directionally, and should therefore result in detecting the appropriate base direction.</p>
+<p>Consumers apply first-strong heuristics to detect the [=string direction=] for the string. The RLM and LRM characters are strongly typed directionally, and should therefore result in detecting the appropriate base direction.</p>
 <p>As described in [[[#firststrong]]], this approach is not relevant if directional information is provided via metadata.</p>
 </section>
 
@@ -859,7 +856,7 @@ data in an interchange format is not a good idea. These include:</p>
 <p>A significant  problem with this, especially on mobile devices, is the 
   availability or inconvenience of inputting an RLM/LRM character. The keyboards of mobile devices generally do not provide keys for RLM/LRM characters. Perhaps more important, because the characters are invisible and because Unicode 
   bidi is complicated, it can be difficult for the user to know how to use the character effectively. In fact, a large percentage of users don't actually know what these characters are or what they do.</p>
-<p>Furthermore, if a person types information into, say, an HTML form in a RTL page or uses shortcut keys to set the direction for the form field, the strings will look correct without the need to add RLM/LRM. However, used outside of that context the string would look incorrect unless it is associated with information about the required [=paragraph direction=]. Similarly, strings scraped from a web page that has <code class="kw" translate="no">dir=rtl</code> set in the <code class="kw" translate="no">html</code> element would not normally have or need an RLM/LRM character at the start of the string in HTML.</p>
+<p>Furthermore, if a person types information into, say, an HTML form in a RTL page or uses shortcut keys to set the direction for the form field, the strings will look correct without the need to add RLM/LRM. However, used outside of that context, the string would look incorrect unless it is associated with information about the required [=block direction=]. Similarly, strings scraped from a web page that has <code class="kw" translate="no">dir=rtl</code> set in the <code class="kw" translate="no">html</code> element would not normally have or need an RLM/LRM character at the start of the string in HTML.</p>
 <p>It may be possible for the steps used by a producer  to include an examination of the original context of the string for directional information (for example, by testing the computed direction of an HTML form field), followed by automatic insertion of an RLM/LRM mark into the beginning of the string where necessary. An issue with this approach is that it changes the string value and identity. This may also create problems for working with string length 
 or pointer positions, especially if some producers add markers and others don't.</p>
 <p>If directional information is contained in markup that will be 
@@ -892,7 +889,7 @@ access, to the original context of the string. Many document formats are generat
 
 <section>
 <h4>How it works</h4>
-<p>A producer ascertains the [=paragraph direction=] of the string and adds a directional formatting character (one of <span class="unicode">U+2066 LEFT-TO-RIGHT ISOLATE</span> (LRI), <span class="unicode">U+2067 RIGHT-TO-LEFT ISOLATE</span> (RLI),<span class="unicode"> U+2068 FIRST STRONG ISOLATE</span> (FSI),<span class="unicode"> U+202A LEFT-TO-RIGHT EMBEDDING</span> (LRE), or <span class="unicode">U+202B RIGHT-TO-LEFT EMBEDDING</span> (RLE)) to the beginning of the string, and  <span class="unicode">U+2069 POP DIRECTIONAL ISOLATE</span> (PDI) or  <span class="unicode">U+202C POP DIRECTIONAL FORMATTING</span> (PDF) to the end.</p>
+<p>A producer ascertains the [=string direction=] of the string and adds a directional formatting character (one of <span class="unicode">U+2066 LEFT-TO-RIGHT ISOLATE</span> (LRI), <span class="unicode">U+2067 RIGHT-TO-LEFT ISOLATE</span> (RLI),<span class="unicode"> U+2068 FIRST STRONG ISOLATE</span> (FSI),<span class="unicode"> U+202A LEFT-TO-RIGHT EMBEDDING</span> (LRE), or <span class="unicode">U+202B RIGHT-TO-LEFT EMBEDDING</span> (RLE)) to the beginning of the string, and  <span class="unicode">U+2069 POP DIRECTIONAL ISOLATE</span> (PDI) or  <span class="unicode">U+202C POP DIRECTIONAL FORMATTING</span> (PDF) to the end.</p>
 <p>There are a number of possible approaches:</p>
 <ol>
 <li>Add the formatting codes to every string.</li>
@@ -984,12 +981,12 @@ access, to the original context of the string. Many document formats are generat
 <ol>
 <li>Label every string for language, including a script subtag as needed. <a>Consumers</a> may need to compute the script subtag when the <a>producer</a> does not provide one.</li>
 <li>It might be reasonable to assume a default of LTR for all strings unless marked with a language tag whose script subtag (either present or implied) indicates RTL.</li>
-<li>Alternatively, limit the use of script subtag metadata to situations where <a href="#firststrong">first-strong heuristics</a> are expected to fail &mdash; provided that such cases can be identified, and appropriate action taken by the producer (not always reliable). <a>Consumers</a> would then need to use first-strong heuristics in the absence of a script subtag in order to identify the appropriate [=paragraph direction=]. The use of script subtags should not, however, be restricted to strings that need to indicate direction; it is perfectly valid to associate a script subtag with any string.</li>
+<li>Alternatively, limit the use of script subtag metadata to situations where <a href="#firststrong">first-strong heuristics</a> are expected to fail &mdash; provided that such cases can be identified, and appropriate action taken by the producer (not always reliable). <a>Consumers</a> would then need to use first-strong heuristics in the absence of a script subtag in order to identify the appropriate [=string direction=]. The use of script subtags should not, however, be restricted to strings that need to indicate direction; it is perfectly valid to associate a script subtag with any string.</li>
 <li>Set a default language for a set of strings at a higher level, but provide a mechanism to override that default for a given string where needed.</li>
 </ol>
-<p><a>Consumers</a> extract the script subtag from the language tag associated with each string, computing the string's [=paragraph direction=] as necessary. Script subtags associated with RTL scripts are used to assign a direction of RTL to their associated strings.</p>
+<p><a>Consumers</a> extract the script subtag from the language tag associated with each string, computing the string's [=string direction=] as necessary. Script subtags associated with RTL scripts are used to assign a direction of RTL to their associated strings.</p>
 
-<p>Language information MUST use [[BCP47]] language tags. The portion of the language tag that carries the information is the script subtag, not the primary language subtag. For example, Azeri may be written LTR (with the Latin or Cyrillic scripts) or RTL (with the Arabic script).  Thus, the subtag <code class="kw" translate="no">az</code> is insufficient to clarify intended [=paragraph direction=]. A language tag such as <code class="kw" translate="no">az-Arab</code> (Azeri as written in the Arabic script), however, can generally be relied upon to indicate that the [=paragraph direction=] should be RTL. </p>
+<p>Language information MUST use [[BCP47]] language tags. The portion of the language tag that carries the information is the script subtag, not the primary language subtag. For example, Azeri may be written LTR (with the Latin or Cyrillic scripts) or RTL (with the Arabic script).  Thus, the subtag <code class="kw" translate="no">az</code> is insufficient to clarify intended [=block direction=]. A language tag such as <code class="kw" translate="no">az-Arab</code> (Azeri as written in the Arabic script), however, can generally be relied upon to indicate that the [=block direction=] should be RTL. </p>
  
 <aside class="note">
 	
@@ -1005,8 +1002,8 @@ access, to the original context of the string. Many document formats are generat
 <h4>Advantages</h4>
 
 <p>There is no need to inspect or change the string itself.</p>
-<p>This approach avoids the issues associated with first-strong detection when the first-strong character is not indicative of the necessary [=paragraph direction=] for the string, and avoids issues relating to the interpretation of markup.</p>
-<p>Note that a string that begins with markup that sets a language for the string text content (eg. <code translate="no">&lt;cite lang="zh-Hans"&gt;</code>) is not problematic here, since that language declaration is not expected to play into the setting of the [=paragraph direction=].</p>
+<p>This approach avoids the issues associated with first-strong detection when the first-strong character is not indicative of the necessary [=string direction=] for the string, and avoids issues relating to the interpretation of markup.</p>
+<p>Note that a string that begins with markup that sets a language for the string text content (eg. <code translate="no">&lt;cite lang="zh-Hans"&gt;</code>) is not problematic here, since that language declaration is not expected to play into the setting of the [=string direction=].</p>
 </section>
 
 
@@ -1014,7 +1011,7 @@ access, to the original context of the string. Many document formats are generat
 <section>
 <h4>Issues</h4>
 <p>The use of metadata as outlined above is a much better approach, if it is available. This script-related approach is only for use where that approach is unavailable, for legacy reasons.</p>
-<p>There are many strings which are not language-specific but which absolutely need to be associated with a particular [=paragraph direction=] for correct consumption. For example, MAC addresses inserted into a RTL context need to be displayed with a LTR overall base direction and also be isolated from the surrounding text. It's not clear how to distinguish these cases from others (in a way that would be feasible when using direction metadata). Special language tags, such as <code class="kw">zxx</code> (Non-Linguistic), exist for identifying this type of content, but usually data fields of this type omit language information altogether, since it is not applicable.</p>
+<p>There are many strings which are not language-specific but which absolutely need to be associated with a particular [=block direction=] for correct consumption. For example, MAC addresses inserted into a RTL context need to be displayed with a LTR overall base direction and also be isolated from the surrounding text. It's not clear how to distinguish these cases from others (in a way that would be feasible when using direction metadata). Special language tags, such as <code class="kw">zxx</code> (Non-Linguistic), exist for identifying this type of content, but usually data fields of this type omit language information altogether, since it is not applicable.</p>
 <p>The list of script subtags may be added to in future. In that case, any subtags that indicate a default RTL direction need to be added to the lists used by the consumers of the strings.</p>
 <p>There are some rare situations where the appropriate [=paragraph direction=] cannot be identified from the script subtag, but these are really limited to archaic usage of text.  For example, Japanese and Chinese text prior to World War 2 was often written RTL, rather than LTR. Languages such as those written using Egyptian Hieroglyphs, or the Tifinagh Berber script, could formerly be written either LTR or RTL, however the default for scholastic research tends to LTR.</p>
 </section>
@@ -1023,7 +1020,7 @@ access, to the original context of the string. Many document formats are generat
 
 <section>
 <h4>Other comments</h4>
-<p>The approach outlined here is only appropriate when declaring information about the <em>overall</em> <a>paragraph direction</a> to be associated with a string. We do <em>not</em> recommend  use of language data to indicate text direction within strings, since the usage patterns are not interchangeable.</p>
+<p>The approach outlined here is only appropriate when declaring information about the <em>overall</em> <a>string direction</a> to be associated with a string. We do <em>not</em> recommend  use of language data to indicate text direction within strings, since the usage patterns are not interchangeable.</p>
 </section>
 </section>
 
@@ -1052,7 +1049,7 @@ access, to the original context of the string. Many document formats are generat
 <p>The benefit for content that already uses markup is clear. The content will already provide complete markup necessary for the display and processing of the text or it can be extracted from the source page context. HTML and XML processors already know how to deal with this markup and provide ready validation.</p>
 <p>For HTML, the <code class="kw" translate="no">dir</code> attribute bidirectionally isolates the content from the surrounding text, which removes spillover conflicts. This reduces the work of the consumer.</p>
 		
-		<p>Markup can also be used for string-internal directional information, something <a>paragraph direction</a> on its own cannot solve.</p>
+		<p>Markup can also be used for string-internal directional information, something <a>string direction</a> on its own cannot solve.</p>
     </section>
     <section>
 		<h4 id="html-content-issues">Issues</h4>
@@ -1092,9 +1089,9 @@ myDataString:          "978-0-123-4567-X"^^i18n:_ltr          // language-neutra
 </aside>
 
 <p>Note that the last string does not include language information  because it is an internal data value, but <em>does</em> include direction information because strings of this kind <em>must</em> be presented in the LTR order.</p>
-<p>A <a>producer</a> would need to attach the <a>paragraph direction</a> to each string as needed.</p>
-<p>Each <a>consumer</a> should use <a href="#firststrong">first-strong heuristics</a> for those strings that don't use this approach or do not contain <a>paragraph direction</a>. The <a>producer</a> would then only add <a>paragraph direction</a> information if the first-strong approach would otherwise produce the wrong result. This might simplify the management of strings and the amount of data to be transmittted, because the number of strings requiring metadata is relatively small.</p>
-<p>The <a>consumer</a> would look to see whether the string has metadata associated with it, in which case it would set the indicated [=paragraph direction=]. Otherwise, it would use first-strong heuristics to determine the paragraph direction of the string.</p>
+<p>A <a>producer</a> would need to attach the <a>string direction</a> to each string as needed.</p>
+<p>Each <a>consumer</a> should use <a href="#firststrong">first-strong heuristics</a> for those strings that don't use this approach or do not contain <a>string direction</a>. The <a>producer</a> would then only add <a>string direction</a> information if the first-strong approach would otherwise produce the wrong result. This might simplify the management of strings and the amount of data to be transmittted, because the number of strings requiring metadata is relatively small.</p>
+<p>The <a>consumer</a> would look to see whether the string has metadata associated with it, in which case it would set the indicated [=string direction=]. Otherwise, it would use first-strong heuristics to determine the string direction of the string.</p>
 
   </section>
 <section>
@@ -1421,7 +1418,7 @@ myDataString:          "978-0-123-4567-X"^^i18n:_ltr          // language-neutra
 members of the inheriting dictionary.</dd>
 <dt><dfn data-dfn-for="localizable" data-dfn-type="dfn" id="localizable-dir" data-idl="" data-title="dir" class="lint-ignore"><code>
 dir</code></dfn> member</dt>
-<dd>Specifies the [=paragraph direction=] for the human-readable members of an inheriting dictionary.</dd></dl>
+<dd>Specifies the [=string direction=] for the human-readable members of an inheriting dictionary.</dd></dl>
 <div data-dfn-for="TextDirection" data-link-for="TextDirection" id="textdirection-enum" typeof="bibo:Chapter" resource="#textdirection-enum" property="bibo:hasPart">
 	<p id="h-textdirection-enum" resource="#h-textdirection-enum"><dfn data-dfn-for="" data-dfn-type="dfn" id="textdirection" data-idl="" data-title="TextDirection" class="lint-ignore">
 <code>TextDirection</code></dfn> enum</p>


### PR DESCRIPTION
These two terms have been used somewhat interchangeably in the spec. The PR attempts to regularize their use.
`base direction` is used for directionality in general. `paragraph direction` is used for the metadata value wrapped around a given string value.

Making this change I also did some cleanup on formatting and tagged some of our jargon not currently labeled. I also tweaked the text where I thought it was needed.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/aphillips/string-meta/pull/84.html" title="Last updated on Feb 28, 2024, 3:21 PM UTC (bd16d4f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/string-meta/84/2022283...aphillips:bd16d4f.html" title="Last updated on Feb 28, 2024, 3:21 PM UTC (bd16d4f)">Diff</a>