### PR TITLE
Add best practices for writing examples and for producers

### DIFF
--- a/index.html
+++ b/index.html
@@ -373,9 +373,99 @@
 
 <p>Not all resources make use of the available metadata mechanisms. The script subtag of a language tag (or the "likely" script subtag based on [[BCP47]] and [[LDML]]) can sometimes be used to infer a [=block direction=] or [=string direction=] when other data is not available. Using language information is a "last resort" and specifications SHOULD NOT use it as the primary way of indicating [=block direction=]: make the effort to provide for metadata.</p>
 
+<section>
+<h2 id="defining_bidi_keywords">Defining Bidirectional Keywords in Specifications</h2>
+
+<p>A specification for a document format or protocol that includes natural language text values will need to define a data field or attribute to store the <a>block direction</a> for each natural language content value. These definitions need to be consistent across the Web in order to ensure interoperability, because <a>consumers</a> of one document format will need to map the <a>block direction</a> for values they receive to fields that they produce or will need to control the <a>string direction</a> of each string when displaying the content. This section describes how to provide such a definition along with the specific content to use.</p>
+
+<p>There are two common use cases for defining content direction: (i) defining a <a>directional metadata field</a> for storing and transmitting the <a>string direction</a> as a field in a data structure or (ii) defining a <a>direction attribute</a> to associate a <a>block direction</a> with a given piece of natural language content.</p>
+
+<p class="definition"><dfn data-lt="directional metadata field|direction field">Directional metadata field</dfn>. A directional metadata field (or <strong>direction field</strong> for short) is a field in a data structure used to associate a [=string direction=] with a given natural language string field or data value.</p>
+
+<aside class="example" id="example-direction-metadata">
+	<p><strong>Example of a <a>direction field</a>.</strong> In this JSON fragment, the <code>title</code> structure has a field <code>direction</code> which represents the <a>string direction</a> to use for the field <code>value</code>.</p>
+<pre class="json">"title": {
+	"value": "HTML و CSS: تصميم و إنشاء مواقع الويب",
+	"direction": "rtl",
+	"language": "ar"
+}</pre>
+</aside>
+
+<p class="definition"><dfn data-lt="direction attribute">Direction attribute</dfn>. A direction attribute is a field or value, usually represented by an attribute in markup languages, that provides the [=string direction=] of the associated natural language string content.</p>
+
+<aside class="example">
+
+<p><strong>Example of a <a>direction attribute</a>.</strong> If the JSON in the <a href="#example-direction-metadata">above example</a> of a <a>directional metadata field</a> were received by a process that was assembling a Web page for display, it might fill in a template similar to the top line in this example to produce markup like the second line. Here the <code class="kw" translate="no">dir</code> attribute from [[HTML]] is an example of a <a>direction attribute</a>.</p>
+
+<pre class="html">
+&lt;p dir="{$title.direction}">{$title.value}&lt;/p>
+&lt;p dir="rtl">HTML و CSS: تصميم و إنشاء مواقع الويب&lt;/p>
+</pre>
+	
+</aside>
+
+<div class="req" id="bp-define-field-direction-value">
+   <p class="advisement">Use the field name <code class="kw" translate="no">direction</code> when defining a <a>directional metadata field</a> in a data structure or protocol.</p>
+</div>
+
+<p>The name <code class="kw" translate="no">direction</code> is preferred for data values. The name <code class="kw" translate="no">dir</code> is an acceptable alternative.</p>
+
+<div class="req" id="bp-define-display-dir-attribute">
+   <p class="advisement">Use the field name <code class="kw" translate="no">dir</code> when defining a <a>direction attribute</a>.</p>
+</div>
+
+<p>The name <code class="kw" translate="no">dir</code> is preferred for an attribute, such as in markup languages. Using <code class="kw" translate="no">direction</code> for an attribute is not recommended, since it is long and relatively uncommon for this use case. Note that both [[HTML]] and [[XML10]] have a built-in <code class="kw" translate="no">dir</code> attribute. A <code class="kw" translate="no">dir</code> attribute should have scope within a document and should be defined to provide bidi isolation.</p>
+
+<div class="req" id="bp-define-direction-values">
+   <p class="advisement">Define the values of a <a>directional metadata field</a> or a <a>direction attribute</a> to include and be limited to the values <code class="kw" translate="no">ltr</code>, <code class="kw" translate="no">rtl</code>, and <code class="kw" translate="no">auto</code>.</p>
+</div>
+
+<p>The value <code class="kw" translate="no">ltr</code> indicates a direction of left-to-right, in exactly the same manner indicated by <a href="https://www.w3.org/TR/css-writing-modes/#direction">CSS writing modes</a> [[CSS-WRITING-MODES-4]]</p>
+
+<p>The value <code class="kw" translate="no">rtl</code> indicates a direction of right-to-left, in exactly the same manner indicated by <a href="https://www.w3.org/TR/css-writing-modes/#direction">CSS writing modes</a> [[CSS-WRITING-MODES-4]]</p>
+
+<p>The value <code class="kw" translate="no">auto</code> indicates that the user agent uses the <a href="https://html.spec.whatwg.org/multipage/dom.html#the-dir-attribute">algorithm</a> for <code class="kw" translate="no">auto</code> defined by [[HTML]] to determine the [=block direction=] ("[=paragraph direction=]"). This heuristic looks for the first character with a strong directionality, in a manner analogous to the Paragraph Level determination in the bidirectional algorithm [[UAX9]].</p>
+
+<p>When <code class="kw" translate="no">auto</code> is applied to multiple fields or to a document as a whole, it means that the direction should be individually derived for each field (with string-specific metadata providing an override for cases that cannot be determined automatically). It can be useful for labelling a group of mixed direction strings, when the <a>string direction</a> of most strings can be reliably determined using the first-strong heuristics. Whenever possible, the actual <a>string direction</a> (<code class="kw" translate="no">ltr</code> or <code class="kw" translate="no">rtl</code>) of individual strings should be stored or exchanged instead of <code class="kw" translate="no">auto</code>. Omitting the <a>direction field</a> is preferable when the value is truly unknown.</p>
+
+</section>
+
+<section id="writing-spec-examples">
+<h3 id="bp-writing-spec-examples">Writing Examples in Specifications</h3>
+
+<p>Specifications for document formats or protocols typically include examples. Examples necessarily include natural language text fields. </p>
+
+<div class="req" id="bp-use-serializations-in-examples">
+	<p class="advisement">When creating examples in a specfication, always use the serializations and best practices found in this document for fields that contain [=natural language=] text. If the format or protocol supports a <a href="#resource_wide_default">resource-wide default</a>, show setting the default in the example. If the format or protocol does not support a document-level default or showing the default would be inconvenient, use a <a href="#single-linguistic-field">Single-Language Localizable Text Field</a> or <a href="#language-maps">Language Map</a> in the example.</p>
+</div>
+
+<aside class="example" title="Examples of using best practices">
+<p>Here is an example using a document-level default. It also shows overriding the default, in case you need to demonstrate that. Specifications do not need to include examples of such overrides when they are demonstrating specific features of the document format or protocol.</p>
+
+<pre class="json">
+    "@context": [
+       "@language": "en",
+       "@direction": "ltr"
+    ],
+    "name": "Example University",
+    "description": "The examples 'name' and 'description' use the document-level default.",
+    "french-field": {
+       "value": "Cet exemple est en français",
+       "lang": "fr"
+    },
+    "arabic-field": {
+       "value": "هذا المثال باللغة العربية",
+       "lang": "ar",
+       "dir": "rtl"
+    }
+</pre>
+</aside>
+
+</section>
+
 
 <section id="technology_specific_solutions">
-<h3 id="bp-json-ld">JSON-LD</h3>
+<h3 id="bp-json-ld">Using JSON-LD</h3>
 
 <div class="req" id="bp_use_jsonld_language_context">
 <p class="advisement">Use of [[JSON-LD]] <code class="kw" translate="no">@context</code> and the built-in <code class="kw" translate="no">@language</code> attribute is RECOMMENDED as a document level default.</p>
@@ -437,63 +527,6 @@
 
 <p>Although the field <samp translate="no">reason</samp> is expected to contain a descriptive string, it is defined as an array of bytes (with an expected encoding of UTF-8). Since the underlying protocol does not provide fields for language or direction metadata, it is not possible to accurately derive the values when reading data from the wire and any values generated by producers implementing WebTransport would be dropped when the structure is eventually serialized to the wire format. As a result, consumers cannot know the direction of the string. Using the first-strong heuristic (such as assigning the value <code class="kw" translate="no">auto</code> to an HTML <code class="kw" translate="no">dir</code> attribute when adding the reason message to a text element) is preferred to assigning an arbitrarily computed value. In addition, while the actual language of the field <samp translate="no">reason</samp> cannot be known from the data structure, <a>consumers</a> should assign a value of <code class="kw" translate="no">und</code> (or the empty value) as the language of the field for display and processing purposes.</p>
 </aside>
-
-</section>
-
-<section>
-<h2 id="defining_bidi_keywords">Defining Bidirectional Keywords in Specifications</h2>
-
-<p>A specification for a document format or protocol that includes natural language text values will need to define a data field or attribute to store the <a>block direction</a> for each natural language content value. These definitions need to be consistent across the Web in order to ensure interoperability, because <a>consumers</a> of one document format will need to map the <a>block direction</a> for values they receive to fields that they produce or will need to control the <a>string direction</a> of each string when displaying the content. This section describes how to provide such a definition along with the specific content to use.</p>
-
-<p>There are two common use cases for defining content direction: (i) defining a <a>directional metadata field</a> for storing and transmitting the <a>string direction</a> as a field in a data structure or (ii) defining a <a>direction attribute</a> to associate a <a>block direction</a> with a given piece of natural language content.</p>
-
-<p class="definition"><dfn data-lt="directional metadata field|direction field">Directional metadata field</dfn>. A directional metadata field (or <strong>direction field</strong> for short) is a field in a data structure used to associate a [=string direction=] with a given natural language string field or data value.</p>
-
-<aside class="example" id="example-direction-metadata">
-	<p><strong>Example of a <a>direction field</a>.</strong> In this JSON fragment, the <code>title</code> structure has a field <code>direction</code> which represents the <a>string direction</a> to use for the field <code>value</code>.</p>
-<pre class="json">"title": {
-	"value": "HTML و CSS: تصميم و إنشاء مواقع الويب",
-	"direction": "rtl",
-	"language": "ar"
-}</pre>
-</aside>
-
-<p class="definition"><dfn data-lt="direction attribute">Direction attribute</dfn>. A direction attribute is a field or value, usually represented by an attribute in markup languages, that provides the [=string direction=] of the associated natural language string content.</p>
-
-<aside class="example">
-
-<p><strong>Example of a <a>direction attribute</a>.</strong> If the JSON in the <a href="#example-direction-metadata">above example</a> of a <a>directional metadata field</a> were received by a process that was assembling a Web page for display, it might fill in a template similar to the top line in this example to produce markup like the second line. Here the <code class="kw" translate="no">dir</code> attribute from [[HTML]] is an example of a <a>direction attribute</a>.</p>
-
-<pre class="html">
-&lt;p dir="{$title.direction}">{$title.value}&lt;/p>
-&lt;p dir="rtl">HTML و CSS: تصميم و إنشاء مواقع الويب&lt;/p>
-</pre>
-	
-</aside>
-
-<div class="req" id="bp-define-field-direction-value">
-   <p class="advisement">Use the field name <code class="kw" translate="no">direction</code> when defining a <a>directional metadata field</a> in a data structure or protocol.</p>
-</div>
-
-<p>The name <code class="kw" translate="no">direction</code> is preferred for data values. The name <code class="kw" translate="no">dir</code> is an acceptable alternative.</p>
-
-<div class="req" id="bp-define-display-dir-attribute">
-   <p class="advisement">Use the field name <code class="kw" translate="no">dir</code> when defining a <a>direction attribute</a>.</p>
-</div>
-
-<p>The name <code class="kw" translate="no">dir</code> is preferred for an attribute, such as in markup languages. Using <code class="kw" translate="no">direction</code> for an attribute is not recommended, since it is long and relatively uncommon for this use case. Note that both [[HTML]] and [[XML10]] have a built-in <code class="kw" translate="no">dir</code> attribute. A <code class="kw" translate="no">dir</code> attribute should have scope within a document and should be defined to provide bidi isolation.</p>
-
-<div class="req" id="bp-define-direction-values">
-   <p class="advisement">Define the values of a <a>directional metadata field</a> or a <a>direction attribute</a> to include and be limited to the values <code class="kw" translate="no">ltr</code>, <code class="kw" translate="no">rtl</code>, and <code class="kw" translate="no">auto</code>.</p>
-</div>
-
-<p>The value <code class="kw" translate="no">ltr</code> indicates a direction of left-to-right, in exactly the same manner indicated by <a href="https://www.w3.org/TR/css-writing-modes/#direction">CSS writing modes</a> [[CSS-WRITING-MODES-4]]</p>
-
-<p>The value <code class="kw" translate="no">rtl</code> indicates a direction of right-to-left, in exactly the same manner indicated by <a href="https://www.w3.org/TR/css-writing-modes/#direction">CSS writing modes</a> [[CSS-WRITING-MODES-4]]</p>
-
-<p>The value <code class="kw" translate="no">auto</code> indicates that the user agent uses the <a href="https://html.spec.whatwg.org/multipage/dom.html#the-dir-attribute">algorithm</a> for <code class="kw" translate="no">auto</code> defined by [[HTML]] to determine the [=block direction=] ("[=paragraph direction=]"). This heuristic looks for the first character with a strong directionality, in a manner analogous to the Paragraph Level determination in the bidirectional algorithm [[UAX9]].</p>
-
-<p>When <code class="kw" translate="no">auto</code> is applied to multiple fields or to a document as a whole, it means that the direction should be individually derived for each field (with string-specific metadata providing an override for cases that cannot be determined automatically). It can be useful for labelling a group of mixed direction strings, when the <a>string direction</a> of most strings can be reliably determined using the first-strong heuristics. Whenever possible, the actual <a>string direction</a> (<code class="kw" translate="no">ltr</code> or <code class="kw" translate="no">rtl</code>) of individual strings should be stored or exchanged instead of <code class="kw" translate="no">auto</code>. Omitting the <a>direction field</a> is preferable when the value is truly unknown.</p>
 
 </section>
 

--- a/index.html
+++ b/index.html
@@ -500,6 +500,7 @@
 
 <p>Many strings consist solely of strongly directional characters that are consistent with the overall [=string direction=]. When this direction does not agree with the [=resource-wide default=] (and the default is present), the [=string direction=] needs to be included so that [=consumers=] do not need to introspect the string to determine direction and so that processes (such as filtering and selection) do not mistake the content's direction.</p>
 
+
 </section>
 
 <section id="technology_specific_solutions">

--- a/index.html
+++ b/index.html
@@ -485,8 +485,14 @@
 </div>
 
 <div class="req" id="bp-producer-more-specific-lang">
-	<p class="advisement">[=Producers=] SHOULD NOT omit the language if the value for a given string is more specific than the [=resource-wide default=]. For example, if the resource-wide default value were <code class="kw" translate="no">fr</code> (French) and the string's associated language were <code class="kw" translate="no">fr-FR</code> (French, France), the more-specific string-level value should be included.</p>
+	<p class="advisement">[=Producers=] SHOULD NOT omit the language if the value for a given string is more specific than the [=resource-wide default=].</p>
 </div>
+
+<p>For example, if the [=resource-wide default=] value were <code class="kw" translate="no">fr</code> (French) and the string's associated language were <code class="kw" translate="no">fr-FR</code> (French, France), the [=producer=] ought to generate string-level metadata with the more specific <code class="kw" translate="no">fr-FR</code> tag.</p>
+
+<aside class="note">
+	<p>This is one reason why the <a href="#language-maps">language maps</a> stucture includes the option of overriding the language tag in the value portion of each entry.</p>
+</aside>
 
 <div class="req" id="bp-producer-include-rtl-dir">
 	<p class="advisement">[=Producers=] SHOULD include string-level direction metadata for any content whose [=string direction=] is opposite that of a provided [=resource-wide default=], even if the string itself is unambiguous.</p>

--- a/index.html
+++ b/index.html
@@ -489,8 +489,10 @@
 </div>
 
 <div class="req" id="bp-producer-include-rtl-dir">
-	<p class="advisement">[=Producers=] SHOULD include string-level direction metadata for right-to-left content if the [=resource-wide default=] is present and is not also <code class="kw" translate="no">RTL</code>, even if the string itself is unambiguous.</p>
+	<p class="advisement">[=Producers=] SHOULD include string-level direction metadata for any content whose [=string direction=] is opposite that of a provided [=resource-wide default=], even if the string itself is unambiguous.</p>
 </div>
+
+<p>Many strings consist solely of strongly directional characters that are consistent with the overall [=string direction=]. When this direction does not agree with the [=resource-wide default=] (and the default is present), the [=string direction=] needs to be included so that [=consumers=] do not need to introspect the string to determine direction and so that processes (such as filtering and selection) do not mistake the content's direction.</p>
 
 </section>
 

--- a/index.html
+++ b/index.html
@@ -488,7 +488,7 @@
 	<p class="advisement">[=Producers=] SHOULD include string-specific language metadata if the value for a given string is <em>more specific</em> or entirely different from that of the [=resource-wide default=].</p>
 </div>
 
-<p>For example, if the [=resource-wide default=] value were <code class="kw" translate="no">fr</code> (French) and the string's associated language were <code class="kw" translate="no">fr-FR</code> (French, France), the [=producer=] ought to generate string-level metadata with the more specific <code class="kw" translate="no">fr-FR</code> tag. Similarly, the [=producer=] out to generate string-level metadata if the language were entirely different, such as <code class="kw" translate="no">de</code> (German).</p>
+<p>For example, if the [=resource-wide default=] value were <code class="kw" translate="no">fr</code> (French) and the string's associated language were <code class="kw" translate="no">fr-FR</code> (French, France), the [=producer=] ought to generate string-specific metadata with the more specific <code class="kw" translate="no">fr-FR</code> tag. Similarly, the [=producer=] ought to generate string-specific metadata if the language were entirely different, such as <code class="kw" translate="no">de</code> (German).</p>
 
 <p>A [=language tag=] is more-specific if it contains more subtags.</p>
 

--- a/index.html
+++ b/index.html
@@ -220,7 +220,7 @@
               <p class="advisement">Use field-based metadata or string datatypes to indicate the language and the <a>string direction</a> for individual <a>localizable text</a> values.</p>
            </div>
 
-		  <p>For <a>localizable text</a> fields that appear in a single language, use a data structure to represent the value. The recommended representation is an object with three fields. The field <code>value</code> contains the actual string. The field <code>lang</code> contains a <a>valid</a> [[BCP47]] language tag. The field <code>dir</code> contains the string's <a>string direction</a> (one of the values <code>ltr</code>, <code>rtl</code>, or <code>auto</code>).</p>
+		  <p>For <a>localizable text</a> fields that appear in a single language, use a data structure to represent the value. The recommended representation is an object with three fields. The field <code>value</code> contains the actual string. The field <code>lang</code> contains a <a>valid</a> [[BCP47]] language tag. The field <code>dir</code> contains the string's <a>string direction</a> (one of the values <code>ltr</code>, <code>rtl</code>, and <code>auto</code>).</p>
 		  
 		  <aside class="example" title="Example of a localizable text field">
 		  <pre class="json" id="localizable-text-field">
@@ -481,21 +481,23 @@
 <p>For example, if the resource-wide language of a document is <code class="kw" translate="no">en-US</code> (English, United States), then the resource-wide direction of the document should probably be <code class="kw" translate="no">[=LTR=]</code>, because left-to-right is the direction associated with that language.</p>
 
 <div class="req" id="bp-producer-omit-lang-dir">
-	<p class="advisement">[=Producers=] SHOULD omit the language or direction metadata if a [=resource-wide default=] is provided and the specific string value is consistent with that default.</p>
+	<p class="advisement">[=Producers=] SHOULD NOT include string-specific language or direction metadata if a [=resource-wide default=] is provided and the string-specific value is consistent with that default.</p>
 </div>
 
 <div class="req" id="bp-producer-more-specific-lang">
-	<p class="advisement">[=Producers=] SHOULD NOT omit the language if the value for a given string is more specific than the [=resource-wide default=].</p>
+	<p class="advisement">[=Producers=] SHOULD include string-specific language metadata if the value for a given string is <em>more specific</em> or entirely different from that of the [=resource-wide default=].</p>
 </div>
 
-<p>For example, if the [=resource-wide default=] value were <code class="kw" translate="no">fr</code> (French) and the string's associated language were <code class="kw" translate="no">fr-FR</code> (French, France), the [=producer=] ought to generate string-level metadata with the more specific <code class="kw" translate="no">fr-FR</code> tag.</p>
+<p>For example, if the [=resource-wide default=] value were <code class="kw" translate="no">fr</code> (French) and the string's associated language were <code class="kw" translate="no">fr-FR</code> (French, France), the [=producer=] ought to generate string-level metadata with the more specific <code class="kw" translate="no">fr-FR</code> tag. Similarly, the [=producer=] out to generate string-level metadata if the language were entirely different, such as <code class="kw" translate="no">de</code> (German).</p>
+
+<p>A [=language tag=] is more-specific if it contains more subtags.</p>
 
 <aside class="note">
-	<p>This is one reason why the <a href="#language-maps">language maps</a> stucture includes the option of overriding the language tag in the value portion of each entry.</p>
+	<p>Supporting the encoding of more-specific language tags is one reason why the <a href="#language-maps">language maps</a> stucture includes the option of overriding the language tag in the value portion of each entry. The more-specific tags can assist with processing, such as selecting the right voice in a text-to-speech system or the right dictionary when checking spelling.</p>
 </aside>
 
 <div class="req" id="bp-producer-include-rtl-dir">
-	<p class="advisement">[=Producers=] SHOULD include string-level direction metadata for any content whose [=string direction=] is opposite that of a provided [=resource-wide default=], even if the string itself is unambiguous.</p>
+	<p class="advisement">[=Producers=] SHOULD include string-specific direction metadata for any content whose [=string direction=] is opposite that of a provided [=resource-wide default=], even if the string itself is unambiguous.</p>
 </div>
 
 <p>Many strings consist solely of strongly directional characters that are consistent with the overall [=string direction=]. When this direction does not agree with the [=resource-wide default=] (and the default is present), the [=string direction=] needs to be included so that [=consumers=] do not need to introspect the string to determine direction and so that processes (such as filtering and selection) do not mistake the content's direction.</p>

--- a/index.html
+++ b/index.html
@@ -254,6 +254,8 @@
 	<h4 id="resource_wide_default">Resource-wide Defaults</h4>
 			  
 	<p>When a resource contains a number of natural language strings (and particularly if those string are all in the same language), using the localized string representation described above can become inefficient. To reduce the complexity of encoding these strings, specifications can establish a resource-level default for language and [=string direction=]. These are separate values, as language does not imply direction. There should still be the ability to override either language or direction on any given string value by using the representation found <a href="#single-linguistic-field">above</a>.</p>
+	
+	<p class="definition">A <dfn data-lt="resource-wide default|document-level default">resource-wide default</dfn> is a value that is specified at the resource or document-level and can be applied to any unlabeled value contained by that resource.</p>
 			  
 	 <div class="req" id="bp_default_setting">
         <p class="advisement">Specifications MAY define a mechanism to provide the default language and the default [=string direction=] for all strings in a given resource. However, specifications MUST NOT assume that a resource-wide default is sufficient.  Even if a resource-wide setting is available, it must be possible to use string-specific metadata to override that default.</p>
@@ -262,10 +264,10 @@
 	 <p>If your specification defines its own document level defaults, provide two optional fields:</p>
 			  
 	 <div class="req" id="bp-document-language-default">
-		<p class="advisement">A document-level default language field SHOULD be called <code>language</code> and SHOULD be specified to contain a <a>valid</a> [[BCP47]] language tag. Specifications SHOULD specify that implementations are only require to check if a [[BCP47]] language tag is <a>well-formed</a>.</p>
+		<p class="advisement">A resource-wide default language field SHOULD be called <code>language</code> and SHOULD be specified to contain a <a>valid</a> [[BCP47]] language tag. Specifications SHOULD specify that implementations are only require to check if a [[BCP47]] language tag is <a>well-formed</a>.</p>
 	 </div>
      <div class="req" id="bp-document-direction-default">
-		<p class="advisement">A document-level default <a>block direction</a> field SHOULD be called <code>direction</code> and support the values <code>ltr</code>, <code>rtl</code>, or <code>auto</code>.</p>
+		<p class="advisement">A resource-wide default <a>block direction</a> field SHOULD be called <code>direction</code> and support the values <code>ltr</code>, <code>rtl</code>, or <code>auto</code>.</p>
 	</div>
 
     <aside class="example" title="Example of document level defaults">
@@ -463,6 +465,34 @@
 
 </section>
 
+<section id="guidance-for-producers">
+<h3 id="bp-producers">Guidance for [=Producers=]</h3>
+
+<p>Content [=producers=], including implementers of specifications that provide the various language and direction metadata mechanisms described in this document, have some discretion about how to implement the best practices found here. For example, if a document format provides both a resource-wide default and single-language localizable text fields, which should a user prefer?</p>
+
+<div class="req" id="bp-producer-resource-wide-lang">
+	<p class="advisement">If a [=resource-wide default=] for language is provided by a document format or protocol, it SHOULD always be set to the language most appropriate for the contents of the document. Often this is the [=locale=] of the generating user.</p>
+</div>
+
+<div class="req" id="bp-producer-resource-wide-dir">
+	<p class="advisement">If a [=resource-wide default=] for direction is provided by a document format or protocol, it SHOULD always be set to the direction most associated with the content of the document. Usually this direction is consistent with the document-level language default, if provided.</p>
+</div>
+
+<p>For example, if the resource-wide language of a document is <code class="kw" translate="no">en-US</code> (English, United States), then the resource-wide direction of the document should probably be <code class="kw" translate="no">[=LTR=]</code>, because left-to-right is the direction associated with that language.</p>
+
+<div class="req" id="bp-producer-omit-lang-dir">
+	<p class="advisement">[=Producers=] SHOULD omit the language or direction metadata if a [=resource-wide default=] is provided and the specific string value is consistent with that default.</p>
+</div>
+
+<div class="req" id="bp-producer-more-specific-lang">
+	<p class="advisement">[=Producers=] SHOULD NOT omit the language if the value for a given string is more specific than the [=resource-wide default=]. For example, if the resource-wide default value were <code class="kw" translate="no">fr</code> (French) and the string's associated language were <code class="kw" translate="no">fr-FR</code> (French, France), the more-specific string-level value should be included.</p>
+</div>
+
+<div class="req" id="bp-producer-include-rtl-dir">
+	<p class="advisement">[=Producers=] SHOULD include string-level direction metadata for right-to-left content if the [=resource-wide default=] is present and is not also <code class="kw" translate="no">RTL</code>, even if the string itself is unambiguous.</p>
+</div>
+
+</section>
 
 <section id="technology_specific_solutions">
 <h3 id="bp-json-ld">Using JSON-LD</h3>


### PR DESCRIPTION
Fixes w3c/i18n-action#76

Note that the new text begins on line 433. I moved the JSON-LD section down below the sections about specification writing, resulting in a strange diff. There are no changes to the "defining bidi keywords" section here.

Added a new section for best practices for producers. This is based in part on reviews of some verifiable credentials work. 
- define 'resource-wide default' as a term
- modified some best practices that said "document-level default" to be consistent with our change to using 'resource-wide' instead
- added a section on producers


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/aphillips/string-meta/pull/86.html" title="Last updated on Apr 4, 2024, 11:42 PM UTC (ed5d8af)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/string-meta/86/b6317d5...aphillips:ed5d8af.html" title="Last updated on Apr 4, 2024, 11:42 PM UTC (ed5d8af)">Diff</a>