### PR TITLE
Add conformance section

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,7 +69,7 @@
 <section id="conventions">
 	<h3>Document Conventions</h3>
 	
-<p>In this document [[RFC2119]] keywords in uppercase italics have their usual meaning. We also use these stylistic conventions:</p>
+<p>We use the following stylistic conventions:</p>
 
 <p class="definition-example"><strong>Definitions</strong> appear with a different background color and decoration like this.</p>
 <p class="advisement"><strong>Best practices</strong> appear with a different background color and decoration like this.</p>
@@ -151,6 +151,8 @@
 <p>For example, in the <a href="#base_example">base example</a> below, all of the keys in the JSON document (<code>id</code>, <code>title</code>, <code>authors</code>, <code>language</code>, <code>publisher</code>, and  so on) are syntactic content. The data values, such as the ISBN, the language tag, and the publication date are also syntactic content. Only the actual book title, the author's name, and the publisher's name are natural language data values and thus <a>localizable text</a>.</p>
 </section>
 </section> <!-- Introduction -->
+
+<section id="conformance"></section>
 
 <section>
 <h2 id="bp_and-reco">Best Practices, Recommendations, and Gaps</h2>

--- a/index.html
+++ b/index.html
@@ -69,7 +69,7 @@
 <section id="conventions">
 	<h3>Document Conventions</h3>
 	
-<p>We use the following stylistic conventions:</p>
+<p>This document uses the following stylistic conventions:</p>
 
 <p class="definition-example"><strong>Definitions</strong> appear with a different background color and decoration like this.</p>
 <p class="advisement"><strong>Best practices</strong> appear with a different background color and decoration like this.</p>


### PR DESCRIPTION
Fix #95.

ReSpec generates a basic Conformance section for us, and we can also add our own content to it if we want.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/string-meta/pull/98.html" title="Last updated on Jul 18, 2026, 2:51 AM UTC (a507214)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/string-meta/98/231a7f4...a507214.html" title="Last updated on Jul 18, 2026, 2:51 AM UTC (a507214)">Diff</a>