### PR TITLE
Fix the single language localizable example.

### DIFF
--- a/index.html
+++ b/index.html
@@ -222,14 +222,24 @@
               <p class="advisement">Use field-based metadata or string datatypes to indicate the language and the <a>string direction</a> for individual <a>localizable text</a> values.</p>
            </div>
 
-		  <p>For <a>localizable text</a> fields that appear in a single language, use a data structure to represent the value. The recommended representation is an object with three fields. The field <code>value</code> contains the actual string. The field <code>lang</code> contains a <a>valid</a> [[BCP47]] language tag. The field <code>dir</code> contains the string's <a>string direction</a> (one of the values <code>ltr</code>, <code>rtl</code>, and <code>auto</code>).</p>
-		  
+		  <p>For <a>localizable text</a> fields that appear in a single language,
+		  use a data structure to represent the value.</p>
+
+		  <p>The RECOMMENDED representation (based on the [[JSON-LD 1.1]]
+		  specification) is an object with three fields. The field
+		  <code>@value</code> contains the actual string. The field
+		  <code>@language</code> contains a <a>valid</a> [[BCP47]] language tag. The
+		  field <code>@direction</code> contains the string's <a>string
+		  direction</a> (one of the values <code>ltr</code>, <code>rtl</code>, and
+		  <code>auto</code>). Note: no other values may appear within the "language
+		  value object".</p>
+
 		  <aside class="example" title="Example of a localizable text field">
 		  <pre class="json" id="localizable-text-field">
 "field-name-goes-here": {
-    "value": "This is the string value",
-    "lang": "en-US",
-    "dir": "ltr"
+    "@value": "This is the string value",
+    "@language": "en-US",
+    "@direction": "ltr"
 }
 		  </pre>
 		  </aside>


### PR DESCRIPTION
Fixes issue #12 by matching the existing JSON-LD Language Value Object
approach.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/BigBlueHat/string-meta/pull/103.html" title="Last updated on Sep 11, 2026, 8:14 PM UTC (ff5ff7d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/string-meta/103/231a7f4...BigBlueHat:ff5ff7d.html" title="Last updated on Sep 11, 2026, 8:14 PM UTC (ff5ff7d)">Diff</a>